### PR TITLE
Task/#99

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,63 @@
+name: Release images
+
+# Build and publish backend + frontend images to GHCR on a semver tag.
+#   git tag v1.2.0 && git push origin v1.2.0
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-push:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: backend
+            image: footballhubmanager-backend
+            context: .
+            dockerfile: backend/docker/Dockerfile
+          - name: frontend
+            image: footballhubmanager-frontend
+            context: frontend
+            dockerfile: frontend/Dockerfile
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute image tags
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha
+            type=raw,value=latest
+
+      - name: Build and push ${{ matrix.name }}
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.dockerfile }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/README.md
+++ b/README.md
@@ -112,6 +112,35 @@ Target: **Kubernetes**. Images are published to **GHCR** on a semver tag and the
 is deployed with the Helm chart in [`deploy/helm/footballhub`](deploy/helm/footballhub).
 Full details in the [Deployment Guide](docs/deployment.md).
 
+### Flow at a glance
+
+```mermaid
+sequenceDiagram
+    actor Dev as Developer
+    participant GH as GitHub Actions
+    participant GHCR
+    actor Ops as Operator
+    participant Helm
+    participant Job as Migrate Job
+    participant DB as MySQL
+    participant API as Backend
+
+    Dev->>GH: git push tag vX.Y.Z
+    GH->>GHCR: build & push backend + frontend images
+    Ops->>Helm: helm upgrade --install (image.tag=X.Y.Z)
+    Helm->>Job: pre-upgrade hook, run "migrate"
+    Job->>DB: wait for DB, apply pending vN.sql
+    DB-->>Job: schema at head
+    Job-->>Helm: success (rollout blocked if it fails)
+    Helm->>API: roll out backend + frontend
+    API->>DB: startup check (STRICT): any pending?
+    API-->>Ops: serving via Ingress (/api to backend, / to frontend)
+```
+
+The key guarantee: the migration Job runs **before** the API rolls out and Helm
+blocks the release until it succeeds, so the backend never serves against a stale
+schema (and refuses to boot if it somehow would).
+
 ### 1. Build & publish images (on a tag)
 
 Pushing a `vX.Y.Z` tag triggers `.github/workflows/release.yml`, which builds and
@@ -143,6 +172,19 @@ In Kubernetes this runs as a **`pre-install,pre-upgrade` Helm hook Job** (backen
 image, `migrate`), so the chart blocks the rollout until the schema is current and
 the API never serves against a stale schema. The backend additionally refuses to
 start when migrations are pending (`STRICT_MIGRATION_CHECK=true`, the chart default).
+
+```mermaid
+flowchart TD
+    Start([Deploy a release]) --> Q{"Database already<br/>has data?"}
+    Q -->|No / fresh DB| M["migrate: apply v1..vN in order"]
+    Q -->|Yes, first time on the runner| S["stamp once: baseline to head"]
+    S --> L[Later releases run migrate]
+    M --> T[("schema_migrations<br/>updated")]
+    L --> T
+    T --> G{"Backend startup:<br/>pending migrations?"}
+    G -->|None| OK[API serves traffic]
+    G -->|Pending and STRICT| Fail[Fail fast at boot]
+```
 
 > **First deploy against a database that already has data:** baseline it once so the
 > runner does not try to re-apply versions that are physically present, then migrate

--- a/README.md
+++ b/README.md
@@ -83,6 +83,9 @@ The project solves operational friction for community football organizers:
 - [x] Frontend lint/format/build checks (`eslint` + `prettier` + `vite build`)
 - [x] CI pipeline covering backend quality/tests and frontend quality/build
 - [x] Dependency audit hardening in frontend (`npm audit` currently clean)
+- [x] Container images (backend + frontend) published to GHCR on semver tag
+- [x] Forward-only DB migration runner with `schema_migrations` tracking (no Alembic)
+- [x] Kubernetes Helm chart with a pre-upgrade migration hook (in-cluster or external MySQL)
 
 ## Tech Stack
 
@@ -103,6 +106,77 @@ The project solves operational friction for community football organizers:
    - `just check` (backend format + lint + unit tests)
    - `just frontend-check` (frontend prettier check + eslint + build)
 
+## Deployment
+
+Target: **Kubernetes**. Images are published to **GHCR** on a semver tag and the app
+is deployed with the Helm chart in [`deploy/helm/footballhub`](deploy/helm/footballhub).
+Full details in the [Deployment Guide](docs/deployment.md).
+
+### 1. Build & publish images (on a tag)
+
+Pushing a `vX.Y.Z` tag triggers `.github/workflows/release.yml`, which builds and
+pushes both images to GHCR (tags `1.2.0`, `1.2`, `sha-<sha>`, `latest`):
+
+```bash
+git tag v1.2.0
+git push origin v1.2.0
+```
+
+| Image | Build context | Dockerfile |
+|-------|---------------|------------|
+| `ghcr.io/adrianoggm/footballhubmanager-backend` | repo root | `backend/docker/Dockerfile` |
+| `ghcr.io/adrianoggm/footballhubmanager-frontend` | `frontend/` | `frontend/Dockerfile` |
+
+The backend is a single image with multiple roles via its entrypoint: `serve`
+(default), `migrate`, `stamp [N]`, `status`. The frontend is a static SPA served by
+nginx; the Ingress routes `/api` to the backend and everything else to the frontend.
+
+### 2. Database migrations (no Alembic)
+
+The schema evolves through forward-only `versioning/sql/versions/vN.sql` files. A
+migration runner (`backend/src/db_migrations`) tracks applied versions in
+`schema_migrations` and applies only the pending ones. **MySQL's docker-entrypoint
+init (`actual.sql`) only runs on an empty volume**, so production always evolves via
+the runner — never the init script.
+
+In Kubernetes this runs as a **`pre-install,pre-upgrade` Helm hook Job** (backend
+image, `migrate`), so the chart blocks the rollout until the schema is current and
+the API never serves against a stale schema. The backend additionally refuses to
+start when migrations are pending (`STRICT_MIGRATION_CHECK=true`, the chart default).
+
+> **First deploy against a database that already has data:** baseline it once so the
+> runner does not try to re-apply versions that are physically present, then migrate
+> on later releases:
+>
+> ```bash
+> helm upgrade --install fhm deploy/helm/footballhub \
+>   --set image.tag=1.2.0 --set 'migrations.args={stamp}'
+> ```
+
+Locally: `just db-status`, `just db-migrate`, `just db-stamp [N]`.
+
+### 3. Install with Helm
+
+```bash
+# Production: external/managed MySQL (recommended)
+kubectl create secret generic fhm-db --from-literal=DB_PASSWORD='********'
+helm upgrade --install fhm deploy/helm/footballhub \
+  --set image.tag=1.2.0 \
+  --set mysql.enabled=false \
+  --set externalDatabase.host=your-db-host \
+  --set database.existingSecret=fhm-db \
+  --set ingress.host=app.example.com
+
+# Dev: in-cluster MySQL (StatefulSet). First install disables the migrate hook
+# because the DB is not up yet when pre-install hooks run, then upgrade:
+helm install fhm deploy/helm/footballhub \
+  --set image.tag=1.2.0 --set migrations.enabled=false --set app.strictMigrationCheck=false
+helm upgrade fhm deploy/helm/footballhub --set image.tag=1.2.0
+```
+
+`mysql.enabled` toggles the database mode (in-cluster StatefulSet vs external managed
+DB). See [`deploy/helm/README.md`](deploy/helm/README.md) and `values.yaml` for all options.
+
 ## Documentation
 
 - [Documentation Index](docs/README.md)
@@ -112,6 +186,7 @@ The project solves operational friction for community football organizers:
 - [Frontend Guide](docs/frontend.md)
 - [Frontend Implementation Planning](docs/frontend-implementation-planning.md)
 - [Docker Guide](docs/docker.md)
+- [Deployment Guide](docs/deployment.md)
 - [Database and SQL](docs/database.md)
 - [API Reference (v1)](docs/api.md)
 - [Testing Guide](docs/testing.md)

--- a/backend/docker/Dockerfile
+++ b/backend/docker/Dockerfile
@@ -1,12 +1,33 @@
+# Build context is the REPOSITORY ROOT (not backend/), so the image can bundle
+# both the application code and the versioned SQL migrations the runner applies.
+#   docker build -f backend/docker/Dockerfile -t <img> .
 FROM python:3.13-slim
+
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONPATH=/app/src
 
 WORKDIR /app
 
-COPY requirements.txt ./requirements.txt
+COPY backend/requirements.txt ./requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt
 
-COPY src ./src
+COPY backend/src ./src
+# Migration SQL must live in the image so the migrate Job can apply it.
+COPY versioning/sql ./versioning/sql
+COPY backend/docker/entrypoint.sh /usr/local/bin/entrypoint.sh
+
+RUN chmod +x /usr/local/bin/entrypoint.sh \
+    && addgroup --system app \
+    && adduser --system --ingroup app --home /app app \
+    && chown -R app:app /app
+
+USER app
 
 EXPOSE 8000
 
-CMD ["python", "src/main.py"]
+HEALTHCHECK --interval=15s --timeout=5s --start-period=20s --retries=5 \
+    CMD ["python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/api/').read()"]
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+CMD ["serve"]

--- a/backend/docker/entrypoint.sh
+++ b/backend/docker/entrypoint.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+# Single image, multiple roles. The Kubernetes pre-upgrade migration Job runs
+# `migrate`; the API Deployment runs `serve` (the default).
+set -e
+
+case "${1:-serve}" in
+  serve)
+    exec python src/main.py
+    ;;
+  migrate)
+    exec python -m db_migrations migrate
+    ;;
+  stamp)
+    shift
+    exec python -m db_migrations stamp "$@"
+    ;;
+  status)
+    exec python -m db_migrations status
+    ;;
+  *)
+    # Escape hatch: run an arbitrary command (debugging, one-off scripts).
+    exec "$@"
+    ;;
+esac

--- a/backend/manage.py
+++ b/backend/manage.py
@@ -1,0 +1,17 @@
+"""Dev convenience wrapper for the migration CLI (cross-shell, repo-root paths).
+
+    python backend/manage.py status|migrate|stamp [N]
+
+Inside the image the entrypoint uses `python -m db_migrations` directly (PYTHONPATH
+is set there); this wrapper just puts `backend/src` on the path for local use.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "src"))
+
+from db_migrations.__main__ import main  # noqa: E402
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/src/db_migrations/__init__.py
+++ b/backend/src/db_migrations/__init__.py
@@ -1,0 +1,14 @@
+"""Forward-only SQL schema migrations.
+
+The schema is a series of ``versioning/sql/versions/vN.sql`` files. This package
+tracks which versions are applied in the ``schema_migrations`` table and applies
+the pending ones in numeric order. It is the **production** mechanism: MySQL's
+docker-entrypoint init only runs on an empty data volume, so it cannot evolve a
+database that already holds data.
+
+Policy (per AGENTS.md / CLAUDE.md): raw SQL, no Alembic.
+"""
+
+from db_migrations.runner import Migration, discover, find_migrations_dir, migrate, stamp, status
+
+__all__ = ["Migration", "discover", "find_migrations_dir", "migrate", "stamp", "status"]

--- a/backend/src/db_migrations/__main__.py
+++ b/backend/src/db_migrations/__main__.py
@@ -1,0 +1,49 @@
+"""CLI entrypoint: ``python -m db_migrations <migrate|stamp|status> [args]``.
+
+Used by the backend image entrypoint (the Kubernetes pre-upgrade migration Job
+runs ``migrate``; ``stamp`` baselines an existing database once).
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s %(message)s")
+    args = list(sys.argv[1:] if argv is None else argv)
+    command = args[0] if args else "status"
+
+    # Imported lazily so `status`/help never require a live DB to *parse* args.
+    from db_migrations import runner
+    from persistence.module import engine
+
+    if command == "migrate":
+        applied = runner.migrate(engine)
+        print(f"Applied {len(applied)} migration(s): {', '.join(applied) or 'none'}")
+        return 0
+
+    if command == "stamp":
+        rest = [arg for arg in args[1:] if arg != "--version"]
+        up_to = rest[0] if rest else None
+        stamped = runner.stamp(engine, up_to=up_to)
+        scope = f"up to v{up_to}" if up_to else "current head"
+        print(f"Stamped {len(stamped)} version(s) ({scope}): {', '.join(stamped) or 'none'}")
+        return 0
+
+    if command == "status":
+        migrations, applied = runner.status(engine)
+        for migration in migrations:
+            mark = "x" if migration.version in applied else " "
+            print(f"[{mark}] v{migration.version}  {migration.description}")
+        pending = [m.version for m in migrations if m.version not in applied]
+        print(f"\n{len(applied)} applied, {len(pending)} pending")
+        return 0
+
+    print(f"Unknown command: {command!r} (use migrate|stamp|status)", file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/src/db_migrations/runner.py
+++ b/backend/src/db_migrations/runner.py
@@ -1,0 +1,172 @@
+"""Core migration-runner logic, decoupled from the concrete engine for testing."""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+from sqlalchemy import text
+from sqlalchemy.engine import Connection, Engine
+
+logger = logging.getLogger(__name__)
+
+_VERSION_RE = re.compile(r"^v(\d+)\.sql$", re.IGNORECASE)
+
+# Portable across MySQL (prod) and SQLite (tests). On an existing prod DB the
+# table already exists (created by v1.sql), so IF NOT EXISTS is a no-op there.
+_SCHEMA_MIGRATIONS_DDL = """
+CREATE TABLE IF NOT EXISTS schema_migrations (
+    version VARCHAR(50) PRIMARY KEY,
+    description VARCHAR(255),
+    success TINYINT NOT NULL DEFAULT 1,
+    applied_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+)
+"""
+
+
+@dataclass(frozen=True)
+class Migration:
+    version: str  # numeric part as a string, e.g. "11" (matches schema_migrations)
+    path: Path
+
+    @property
+    def description(self) -> str:
+        return self.path.stem  # e.g. "v11"
+
+
+def find_migrations_dir(explicit: str | Path | None = None) -> Path:
+    """Locate ``versioning/sql/versions`` from an override or by walking upward.
+
+    Works both inside the image (``/app/versioning/sql/versions``) and from a dev
+    checkout (``<repo>/versioning/sql/versions``).
+    """
+    if explicit:
+        return Path(explicit)
+    here = Path(__file__).resolve()
+    for parent in here.parents:
+        candidate = parent / "versioning" / "sql" / "versions"
+        if candidate.is_dir():
+            return candidate
+    raise FileNotFoundError("Could not locate versioning/sql/versions (set MIGRATIONS_DIR)")
+
+
+def discover(migrations_dir: str | Path) -> list[Migration]:
+    directory = Path(migrations_dir)
+    migrations = [
+        Migration(version=str(int(match.group(1))), path=entry)
+        for entry in directory.iterdir()
+        if (match := _VERSION_RE.match(entry.name))
+    ]
+    migrations.sort(key=lambda migration: int(migration.version))
+    return migrations
+
+
+def _split_statements(sql: str) -> list[str]:
+    """Split a `.sql` file into individual statements.
+
+    The DDL files use only simple `;`-terminated statements (no semicolons inside
+    string literals), so a plain split is safe. Fragments that are only comments
+    or whitespace are dropped; leading `--` comments on a real statement are kept
+    (databases ignore them).
+    """
+    statements: list[str] = []
+    for fragment in sql.split(";"):
+        body = "\n".join(
+            line
+            for line in fragment.splitlines()
+            if line.strip() and not line.strip().startswith("--")
+        ).strip()
+        if body:
+            statements.append(fragment.strip())
+    return statements
+
+
+def ensure_table(conn: Connection) -> None:
+    conn.execute(text(_SCHEMA_MIGRATIONS_DDL))
+
+
+def applied_versions(conn: Connection) -> set[str]:
+    rows = conn.execute(text("SELECT version FROM schema_migrations")).scalars()
+    return {str(value) for value in rows}
+
+
+def _record(conn: Connection, version: str, description: str, *, success: bool) -> None:
+    # Idempotent upsert: some legacy files (v1-v8) self-record their version, so a
+    # plain INSERT could clash. DELETE+INSERT is portable and leaves one clean row.
+    conn.execute(text("DELETE FROM schema_migrations WHERE version = :v"), {"v": version})
+    conn.execute(
+        text("INSERT INTO schema_migrations (version, description, success) VALUES (:v, :d, :s)"),
+        {"v": version, "d": description[:255], "s": 1 if success else 0},
+    )
+
+
+def status(
+    engine: Engine, migrations_dir: str | Path | None = None
+) -> tuple[list[Migration], set[str]]:
+    migrations = discover(find_migrations_dir(migrations_dir))
+    with engine.begin() as conn:
+        ensure_table(conn)
+        applied = applied_versions(conn)
+    return migrations, applied
+
+
+def migrate(engine: Engine, migrations_dir: str | Path | None = None) -> list[str]:
+    """Apply every pending migration in order. Returns the versions applied.
+
+    Each migration runs in its own transaction together with its bookkeeping row.
+    NOTE: MySQL performs an implicit commit per DDL statement, so a multi-statement
+    migration that fails midway cannot be fully rolled back — fix forward. The run
+    stops at the first failing migration and re-raises.
+    """
+    directory = find_migrations_dir(migrations_dir)
+    migrations = discover(directory)
+    with engine.begin() as conn:
+        ensure_table(conn)
+        applied = applied_versions(conn)
+
+    pending = [migration for migration in migrations if migration.version not in applied]
+    if not pending:
+        logger.info("No pending migrations (%s applied).", len(applied))
+        return []
+
+    done: list[str] = []
+    for migration in pending:
+        statements = _split_statements(migration.path.read_text(encoding="utf-8"))
+        try:
+            with engine.begin() as conn:
+                for statement in statements:
+                    conn.exec_driver_sql(statement)
+                _record(conn, migration.version, migration.description, success=True)
+        except Exception:
+            logger.exception("Migration %s failed; stopping.", migration.path.name)
+            raise
+        logger.info("Applied migration %s", migration.path.name)
+        done.append(migration.version)
+    return done
+
+
+def stamp(
+    engine: Engine, migrations_dir: str | Path | None = None, up_to: str | int | None = None
+) -> list[str]:
+    """Mark migrations as applied WITHOUT running them.
+
+    One-time baseline for an existing database whose schema was already created
+    (e.g. from ``actual.sql`` or by hand) so ``migrate`` does not try to re-apply
+    versions that are physically present. ``up_to`` limits to ``version <= up_to``
+    (default: every discovered version = current head).
+    """
+    migrations = discover(find_migrations_dir(migrations_dir))
+    if up_to is not None:
+        migrations = [m for m in migrations if int(m.version) <= int(up_to)]
+
+    stamped: list[str] = []
+    with engine.begin() as conn:
+        ensure_table(conn)
+        applied = applied_versions(conn)
+        for migration in migrations:
+            if migration.version not in applied:
+                _record(conn, migration.version, migration.description, success=True)
+                stamped.append(migration.version)
+    return stamped

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -21,7 +21,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.middleware.gzip import GZipMiddleware
 from fastapi.middleware.trustedhost import TrustedHostMiddleware
 from fastapi.responses import JSONResponse
-from sqlalchemy import inspect, text
+from sqlalchemy import text
 from uvicorn import run
 
 # Logger
@@ -103,22 +103,38 @@ def _db_startup_retries() -> tuple[int, float]:
     return max(1, attempts), max(0.1, delay)
 
 
-def _ensure_profile_image_columns() -> None:
-    dialect_name = getattr(getattr(engine, "dialect", None), "name", None)
-    if dialect_name != "mysql":
+def _strict_migration_check() -> bool:
+    raw = os.getenv("STRICT_MIGRATION_CHECK")
+    return raw is not None and raw.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _verify_schema_migrations() -> None:
+    """Read-only check that the database schema is at head.
+
+    Migrations are applied out-of-band (the Kubernetes pre-upgrade Job runs the
+    ``migrate`` command), never by the API process. Here we only verify: when
+    ``STRICT_MIGRATION_CHECK`` is enabled we refuse to start against a stale schema
+    (fail fast and loud) instead of letting requests error at runtime; otherwise we
+    log a warning. Any problem reaching the migration metadata is non-fatal.
+    """
+    try:
+        from db_migrations import runner
+
+        migrations, applied = runner.status(engine)
+    except Exception as exc:
+        logger.warning("Skipped schema migration check: %s", exc)
         return
 
-    with engine.begin() as conn:
-        inspector = inspect(conn)
-        table_columns = {
-            "pena": {column["name"] for column in inspector.get_columns("pena")},
-            "player": {column["name"] for column in inspector.get_columns("player")},
-        }
+    pending = [migration.version for migration in migrations if migration.version not in applied]
+    if not pending:
+        logger.info("Schema is up to date (%s migration(s) applied).", len(applied))
+        return
 
-        if "image_url" not in table_columns["pena"]:
-            conn.execute(text("ALTER TABLE pena ADD COLUMN image_url LONGTEXT NULL"))
-        if "image_url" not in table_columns["player"]:
-            conn.execute(text("ALTER TABLE player ADD COLUMN image_url LONGTEXT NULL"))
+    message = f"Pending schema migrations: {', '.join(pending)}. Apply the migrate job."
+    if _strict_migration_check():
+        logger.error(message)
+        raise RuntimeError(message)
+    logger.warning(message)
 
 
 # Lifespan for startup/shutdown
@@ -153,7 +169,7 @@ async def lifespan(app: FastAPI):
         logger.error("Database connection failed after %s attempts: %s", max_attempts, last_error)
         raise last_error
 
-    _ensure_profile_image_columns()
+    _verify_schema_migrations()
 
     yield
 

--- a/backend/tests/test_db_migrations.py
+++ b/backend/tests/test_db_migrations.py
@@ -1,0 +1,128 @@
+from pathlib import Path
+
+import pytest
+from db_migrations import runner
+from sqlalchemy import create_engine, text
+from sqlalchemy.pool import StaticPool
+
+
+def _engine():
+    # StaticPool keeps a single in-memory DB across the runner's separate
+    # engine.begin() connections (otherwise each connection gets a fresh DB).
+    return create_engine(
+        "sqlite://", connect_args={"check_same_thread": False}, poolclass=StaticPool
+    )
+
+
+def _write(directory: Path, name: str, sql: str) -> None:
+    (directory / name).write_text(sql, encoding="utf-8")
+
+
+def _table_exists(engine, name: str) -> bool:
+    with engine.begin() as conn:
+        row = conn.execute(
+            text("SELECT name FROM sqlite_master WHERE type='table' AND name=:n"), {"n": name}
+        ).first()
+    return row is not None
+
+
+def test_discover_orders_numerically(tmp_path):
+    _write(tmp_path, "v2.sql", "CREATE TABLE t2 (id INTEGER);")
+    _write(tmp_path, "v10.sql", "CREATE TABLE t10 (id INTEGER);")
+    _write(tmp_path, "v1.sql", "CREATE TABLE t1 (id INTEGER);")
+    _write(tmp_path, "notes.txt", "ignore me")
+
+    versions = [m.version for m in runner.discover(tmp_path)]
+
+    assert versions == ["1", "2", "10"]  # 10 after 2, not lexicographic
+
+
+def test_migrate_applies_pending_and_records(tmp_path):
+    _write(tmp_path, "v1.sql", "CREATE TABLE t1 (id INTEGER);")
+    _write(tmp_path, "v2.sql", "CREATE TABLE t2 (id INTEGER);")
+    engine = _engine()
+
+    applied = runner.migrate(engine, migrations_dir=tmp_path)
+
+    assert applied == ["1", "2"]
+    assert _table_exists(engine, "t1")
+    assert _table_exists(engine, "t2")
+    _, recorded = runner.status(engine, migrations_dir=tmp_path)
+    assert recorded == {"1", "2"}
+
+
+def test_migrate_is_idempotent(tmp_path):
+    _write(tmp_path, "v1.sql", "CREATE TABLE t1 (id INTEGER);")
+    engine = _engine()
+
+    assert runner.migrate(engine, migrations_dir=tmp_path) == ["1"]
+    # A second run finds nothing pending and does not re-run v1 (which would fail
+    # with "table already exists").
+    assert runner.migrate(engine, migrations_dir=tmp_path) == []
+
+
+def test_migrate_only_runs_new_versions(tmp_path):
+    _write(tmp_path, "v1.sql", "CREATE TABLE t1 (id INTEGER);")
+    engine = _engine()
+    runner.migrate(engine, migrations_dir=tmp_path)
+
+    _write(tmp_path, "v2.sql", "CREATE TABLE t2 (id INTEGER);")
+    assert runner.migrate(engine, migrations_dir=tmp_path) == ["2"]
+
+
+def test_migrate_handles_multi_statement_and_comments(tmp_path):
+    _write(
+        tmp_path,
+        "v1.sql",
+        "-- header comment\nCREATE TABLE t1 (id INTEGER);\nCREATE TABLE t2 (id INTEGER);\n",
+    )
+    engine = _engine()
+
+    assert runner.migrate(engine, migrations_dir=tmp_path) == ["1"]
+    assert _table_exists(engine, "t1")
+    assert _table_exists(engine, "t2")
+
+
+def test_migrate_stops_and_raises_on_failure(tmp_path):
+    _write(tmp_path, "v1.sql", "CREATE TABLE t1 (id INTEGER);")
+    _write(tmp_path, "v2.sql", "THIS IS NOT VALID SQL;")
+    _write(tmp_path, "v3.sql", "CREATE TABLE t3 (id INTEGER);")
+    engine = _engine()
+
+    with pytest.raises(Exception):
+        runner.migrate(engine, migrations_dir=tmp_path)
+
+    # v1 committed, v2 failed, v3 never ran.
+    _, recorded = runner.status(engine, migrations_dir=tmp_path)
+    assert recorded == {"1"}
+    assert not _table_exists(engine, "t3")
+
+
+def test_stamp_marks_applied_without_running(tmp_path):
+    # If this ran it would create the table; stamping must NOT run it.
+    _write(tmp_path, "v1.sql", "CREATE TABLE t1 (id INTEGER);")
+    _write(tmp_path, "v2.sql", "CREATE TABLE t2 (id INTEGER);")
+    engine = _engine()
+
+    stamped = runner.stamp(engine, migrations_dir=tmp_path)
+
+    assert stamped == ["1", "2"]
+    assert not _table_exists(engine, "t1")
+    assert not _table_exists(engine, "t2")
+    # A subsequent migrate sees everything as applied and does nothing.
+    assert runner.migrate(engine, migrations_dir=tmp_path) == []
+
+
+def test_stamp_up_to_then_migrate_runs_the_rest(tmp_path):
+    _write(tmp_path, "v1.sql", "CREATE TABLE t1 (id INTEGER);")
+    _write(tmp_path, "v2.sql", "CREATE TABLE t2 (id INTEGER);")
+    _write(tmp_path, "v3.sql", "CREATE TABLE t3 (id INTEGER);")
+    engine = _engine()
+
+    assert runner.stamp(engine, migrations_dir=tmp_path, up_to=2) == ["1", "2"]
+
+    applied = runner.migrate(engine, migrations_dir=tmp_path)
+
+    assert applied == ["3"]
+    assert not _table_exists(engine, "t1")  # stamped, never run
+    assert _table_exists(engine, "t3")  # genuinely migrated

--- a/backend/tests/test_main_migration_check.py
+++ b/backend/tests/test_main_migration_check.py
@@ -1,0 +1,51 @@
+from pathlib import Path
+
+import main
+import pytest
+from db_migrations.runner import Migration
+
+
+def _status(monkeypatch, migrations, applied):
+    monkeypatch.setattr(
+        "db_migrations.runner.status", lambda _engine, *a, **k: (migrations, applied)
+    )
+
+
+def test_verify_passes_when_up_to_date(monkeypatch):
+    _status(monkeypatch, [Migration("1", Path("v1.sql"))], {"1"})
+    # No exception regardless of strict mode.
+    monkeypatch.setenv("STRICT_MIGRATION_CHECK", "true")
+    main._verify_schema_migrations()
+
+
+def test_verify_warns_when_pending_and_not_strict(monkeypatch):
+    _status(monkeypatch, [Migration("1", Path("v1.sql")), Migration("2", Path("v2.sql"))], {"1"})
+    monkeypatch.delenv("STRICT_MIGRATION_CHECK", raising=False)
+    # Pending v2 but not strict -> warning only, no raise.
+    main._verify_schema_migrations()
+
+
+def test_verify_raises_when_pending_and_strict(monkeypatch):
+    _status(monkeypatch, [Migration("1", Path("v1.sql")), Migration("2", Path("v2.sql"))], {"1"})
+    monkeypatch.setenv("STRICT_MIGRATION_CHECK", "1")
+    with pytest.raises(RuntimeError, match="Pending schema migrations: 2"):
+        main._verify_schema_migrations()
+
+
+def test_verify_is_non_fatal_when_status_errors(monkeypatch):
+    def _boom(_engine, *a, **k):
+        raise RuntimeError("db unreachable")
+
+    monkeypatch.setattr("db_migrations.runner.status", _boom)
+    monkeypatch.setenv("STRICT_MIGRATION_CHECK", "true")
+    # A problem reaching migration metadata must not crash startup.
+    main._verify_schema_migrations()
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [("true", True), ("1", True), ("yes", True), ("on", True), ("false", False), ("", False)],
+)
+def test_strict_flag_parsing(monkeypatch, value, expected):
+    monkeypatch.setenv("STRICT_MIGRATION_CHECK", value)
+    assert main._strict_migration_check() is expected

--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -1,0 +1,45 @@
+# footballhub Helm chart
+
+Deploys the backend API, the frontend SPA, an optional in-cluster MySQL, and runs
+schema migrations as a pre-install/pre-upgrade hook. See `../../docs/deployment.md`
+for the migration model and `values.yaml` for all options.
+
+> Not yet rendered locally (no `helm` in this environment). Validate before use:
+> `helm lint deploy/helm/footballhub` and `helm template r deploy/helm/footballhub`.
+
+## Quick start (dev, in-cluster MySQL)
+
+First install must disable the migration hook (the MySQL StatefulSet is not up yet
+when Helm runs pre-install hooks), then upgrade:
+
+```bash
+helm install fhm deploy/helm/footballhub \
+  --set image.tag=1.2.0 \
+  --set migrations.enabled=false
+helm upgrade fhm deploy/helm/footballhub --set image.tag=1.2.0
+```
+
+## Production (external/managed MySQL)
+
+```bash
+# Store the DB password out-of-band:
+kubectl create secret generic fhm-db --from-literal=DB_PASSWORD='********'
+
+helm upgrade --install fhm deploy/helm/footballhub \
+  --set image.tag=1.2.0 \
+  --set mysql.enabled=false \
+  --set externalDatabase.host=your-db-host \
+  --set database.existingSecret=fhm-db \
+  --set ingress.host=app.example.com
+```
+
+## First deploy against a database that already has data
+
+Baseline it once (mark present versions applied, don't re-run them), then migrate
+on later releases:
+
+```bash
+helm upgrade --install fhm deploy/helm/footballhub \
+  --set image.tag=1.2.0 --set 'migrations.args={stamp}'
+# subsequent releases use the default migrations.args = {migrate}
+```

--- a/deploy/helm/footballhub/Chart.yaml
+++ b/deploy/helm/footballhub/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: footballhub
+description: FootballHubManager — backend API, frontend SPA, and forward-only DB migrations
+type: application
+version: 0.1.0
+appVersion: "1.0.0"

--- a/deploy/helm/footballhub/templates/NOTES.txt
+++ b/deploy/helm/footballhub/templates/NOTES.txt
@@ -1,0 +1,33 @@
+{{ include "footballhub.fullname" . }} deployed.
+
+Images:
+  backend:  {{ include "footballhub.backendImage" . }}
+  frontend: {{ include "footballhub.frontendImage" . }}
+
+Database: {{ if .Values.mysql.enabled }}in-cluster MySQL ({{ include "footballhub.dbHost" . }}){{ else }}external ({{ .Values.externalDatabase.host }}){{ end }}
+
+Migrations: {{ if .Values.migrations.enabled }}run as a pre-install/pre-upgrade hook ({{ .Values.migrations.args | toJson }}){{ else }}DISABLED{{ end }}
+
+{{- if and .Values.mysql.enabled .Values.migrations.enabled }}
+
+⚠ FIRST INSTALL with in-cluster MySQL:
+  Helm runs the migration hook BEFORE normal resources, so the MySQL StatefulSet
+  is not up yet on `helm install` and the hook would time out. Install once with
+  migrations disabled, then upgrade:
+
+    helm install {{ .Release.Name }} ./deploy/helm/footballhub \
+      --set migrations.enabled=false --set app.strictMigrationCheck=false
+    helm upgrade {{ .Release.Name }} ./deploy/helm/footballhub
+
+  (Production with an external/managed DB does not have this caveat.)
+{{- end }}
+
+{{- if not .Values.ingress.enabled }}
+
+Ingress is disabled — expose the services yourself (e.g. kubectl port-forward
+svc/{{ include "footballhub.fullname" . }}-frontend 8080:80).
+{{- end }}
+
+First deploy against an EXISTING database? Baseline it instead of migrating:
+  --set migrations.args="{stamp}"      # mark all present versions as applied
+Then switch back to {migrate} for subsequent releases. See docs/deployment.md.

--- a/deploy/helm/footballhub/templates/_helpers.tpl
+++ b/deploy/helm/footballhub/templates/_helpers.tpl
@@ -1,0 +1,57 @@
+{{/* Base name + fullname */}}
+{{- define "footballhub.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "footballhub.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name (include "footballhub.name" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "footballhub.labels" -}}
+app.kubernetes.io/name: {{ include "footballhub.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version }}
+{{- end -}}
+
+{{/* Image references */}}
+{{- define "footballhub.backendImage" -}}
+{{- $tag := .Values.image.tag | default .Chart.AppVersion -}}
+{{- printf "%s/%s/%s:%s" .Values.image.registry .Values.image.owner .Values.backend.image.repository $tag -}}
+{{- end -}}
+
+{{- define "footballhub.frontendImage" -}}
+{{- $tag := .Values.image.tag | default .Chart.AppVersion -}}
+{{- printf "%s/%s/%s:%s" .Values.image.registry .Values.image.owner .Values.frontend.image.repository $tag -}}
+{{- end -}}
+
+{{/* DB host depends on the mode */}}
+{{- define "footballhub.dbHost" -}}
+{{- if .Values.mysql.enabled -}}
+{{- printf "%s-mysql" (include "footballhub.fullname" .) -}}
+{{- else -}}
+{{- required "externalDatabase.host is required when mysql.enabled is false" .Values.externalDatabase.host -}}
+{{- end -}}
+{{- end -}}
+
+{{/* Secret name holding DB_PASSWORD (and MYSQL_* when in-cluster) */}}
+{{- define "footballhub.dbSecretName" -}}
+{{- if .Values.database.existingSecret -}}
+{{- .Values.database.existingSecret -}}
+{{- else -}}
+{{- printf "%s-db" (include "footballhub.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{/* DB_PASSWORD env entry (shared by backend + migrate Job) */}}
+{{- define "footballhub.dbPasswordEnv" -}}
+- name: DB_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "footballhub.dbSecretName" . }}
+      key: {{ .Values.database.passwordSecretKey }}
+{{- end -}}

--- a/deploy/helm/footballhub/templates/backend.yaml
+++ b/deploy/helm/footballhub/templates/backend.yaml
@@ -1,0 +1,64 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "footballhub.fullname" . }}-backend
+  labels:
+    {{- include "footballhub.labels" . | nindent 4 }}
+    app.kubernetes.io/component: backend
+spec:
+  replicas: {{ .Values.backend.replicas }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "footballhub.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: backend
+  template:
+    metadata:
+      labels:
+        {{- include "footballhub.labels" . | nindent 8 }}
+        app.kubernetes.io/component: backend
+    spec:
+      containers:
+        - name: backend
+          image: {{ include "footballhub.backendImage" . | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args: ["serve"]
+          ports:
+            - name: http
+              containerPort: {{ .Values.backend.containerPort }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "footballhub.fullname" . }}-config
+          env:
+            {{- include "footballhub.dbPasswordEnv" . | nindent 12 }}
+          readinessProbe:
+            httpGet:
+              path: /api/
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /api/
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          resources:
+            {{- toYaml .Values.backend.resources | nindent 12 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "footballhub.fullname" . }}-backend
+  labels:
+    {{- include "footballhub.labels" . | nindent 4 }}
+    app.kubernetes.io/component: backend
+spec:
+  selector:
+    app.kubernetes.io/name: {{ include "footballhub.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: backend
+  ports:
+    - name: http
+      port: 80
+      targetPort: http

--- a/deploy/helm/footballhub/templates/config.yaml
+++ b/deploy/helm/footballhub/templates/config.yaml
@@ -1,0 +1,42 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "footballhub.fullname" . }}-config
+  labels:
+    {{- include "footballhub.labels" . | nindent 4 }}
+data:
+  APP_ENV: {{ .Values.app.env | quote }}
+  APP_HOST: "0.0.0.0"
+  APP_PORT: {{ .Values.backend.containerPort | quote }}
+  APP_RELOAD: "false"
+  ALLOWED_HOSTS: {{ .Values.app.allowedHosts | quote }}
+  CORS_ALLOWED_ORIGINS: {{ .Values.app.corsAllowedOrigins | quote }}
+  LINK_TOKEN_TTL_SECONDS: {{ .Values.app.linkTokenTtlSeconds | quote }}
+  SESSION_TTL_SECONDS: {{ .Values.app.sessionTtlSeconds | quote }}
+  STRICT_MIGRATION_CHECK: {{ .Values.app.strictMigrationCheck | quote }}
+  DB_HOST: {{ include "footballhub.dbHost" . | quote }}
+  DB_PORT: {{ .Values.database.port | quote }}
+  DB_NAME: {{ .Values.database.name | quote }}
+  DB_USER: {{ .Values.database.user | quote }}
+  DB_PROVIDER: {{ .Values.database.provider | quote }}
+  {{- range $key, $value := .Values.app.extraEnv }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}
+{{- if not .Values.database.existingSecret }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "footballhub.dbSecretName" . }}
+  labels:
+    {{- include "footballhub.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{ .Values.database.passwordSecretKey }}: {{ .Values.mysql.password | quote }}
+  {{- if .Values.mysql.enabled }}
+  MYSQL_ROOT_PASSWORD: {{ .Values.mysql.rootPassword | quote }}
+  MYSQL_DATABASE: {{ .Values.database.name | quote }}
+  MYSQL_USER: {{ .Values.database.user | quote }}
+  MYSQL_PASSWORD: {{ .Values.mysql.password | quote }}
+  {{- end }}
+{{- end }}

--- a/deploy/helm/footballhub/templates/frontend.yaml
+++ b/deploy/helm/footballhub/templates/frontend.yaml
@@ -1,0 +1,52 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "footballhub.fullname" . }}-frontend
+  labels:
+    {{- include "footballhub.labels" . | nindent 4 }}
+    app.kubernetes.io/component: frontend
+spec:
+  replicas: {{ .Values.frontend.replicas }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "footballhub.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: frontend
+  template:
+    metadata:
+      labels:
+        {{- include "footballhub.labels" . | nindent 8 }}
+        app.kubernetes.io/component: frontend
+    spec:
+      containers:
+        - name: frontend
+          image: {{ include "footballhub.frontendImage" . | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.frontend.containerPort }}
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 3
+            periodSeconds: 10
+          resources:
+            {{- toYaml .Values.frontend.resources | nindent 12 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "footballhub.fullname" . }}-frontend
+  labels:
+    {{- include "footballhub.labels" . | nindent 4 }}
+    app.kubernetes.io/component: frontend
+spec:
+  selector:
+    app.kubernetes.io/name: {{ include "footballhub.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: frontend
+  ports:
+    - name: http
+      port: 80
+      targetPort: http

--- a/deploy/helm/footballhub/templates/ingress.yaml
+++ b/deploy/helm/footballhub/templates/ingress.yaml
@@ -1,0 +1,40 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "footballhub.fullname" . }}
+  labels:
+    {{- include "footballhub.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.ingress.host | quote }}
+      http:
+        paths:
+          # API first: /api goes to the backend.
+          - path: /api
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "footballhub.fullname" . }}-backend
+                port:
+                  number: 80
+          # Everything else is the SPA.
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "footballhub.fullname" . }}-frontend
+                port:
+                  number: 80
+{{- end }}

--- a/deploy/helm/footballhub/templates/migrate-job.yaml
+++ b/deploy/helm/footballhub/templates/migrate-job.yaml
@@ -1,0 +1,49 @@
+{{- if .Values.migrations.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "footballhub.fullname" . }}-migrate
+  labels:
+    {{- include "footballhub.labels" . | nindent 4 }}
+    app.kubernetes.io/component: migrate
+  annotations:
+    # Run before the API rolls out, and block the release until it succeeds, so
+    # the backend never serves against an un-migrated schema.
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 1
+  template:
+    metadata:
+      labels:
+        {{- include "footballhub.labels" . | nindent 8 }}
+        app.kubernetes.io/component: migrate
+    spec:
+      restartPolicy: Never
+      initContainers:
+        # Wait for the database to accept TCP before migrating. (With an external
+        # managed DB this is instant; with in-cluster MySQL on the very first
+        # install see NOTES.txt — set migrations.enabled=false for the install.)
+        - name: wait-for-db
+          image: busybox:1.36
+          command:
+            - sh
+            - -c
+            - |
+              until nc -z {{ include "footballhub.dbHost" . }} {{ .Values.database.port }}; do
+                echo "waiting for database..."; sleep 2;
+              done
+      containers:
+        - name: migrate
+          image: {{ include "footballhub.backendImage" . | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args: {{ .Values.migrations.args | toJson }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "footballhub.fullname" . }}-config
+          env:
+            {{- include "footballhub.dbPasswordEnv" . | nindent 12 }}
+          resources:
+            {{- toYaml .Values.migrations.resources | nindent 12 }}
+{{- end }}

--- a/deploy/helm/footballhub/templates/mysql.yaml
+++ b/deploy/helm/footballhub/templates/mysql.yaml
@@ -1,0 +1,84 @@
+{{- if .Values.mysql.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "footballhub.fullname" . }}-mysql
+  labels:
+    {{- include "footballhub.labels" . | nindent 4 }}
+    app.kubernetes.io/component: mysql
+spec:
+  clusterIP: None
+  selector:
+    app.kubernetes.io/name: {{ include "footballhub.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: mysql
+  ports:
+    - name: mysql
+      port: {{ .Values.database.port }}
+      targetPort: mysql
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "footballhub.fullname" . }}-mysql
+  labels:
+    {{- include "footballhub.labels" . | nindent 4 }}
+    app.kubernetes.io/component: mysql
+spec:
+  serviceName: {{ include "footballhub.fullname" . }}-mysql
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "footballhub.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: mysql
+  template:
+    metadata:
+      labels:
+        {{- include "footballhub.labels" . | nindent 8 }}
+        app.kubernetes.io/component: mysql
+    spec:
+      containers:
+        - name: mysql
+          image: {{ .Values.mysql.image | quote }}
+          ports:
+            - name: mysql
+              containerPort: {{ .Values.database.port }}
+          env:
+            - name: MYSQL_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "footballhub.dbSecretName" . }}
+                  key: MYSQL_ROOT_PASSWORD
+            - name: MYSQL_DATABASE
+              value: {{ .Values.database.name | quote }}
+            - name: MYSQL_USER
+              value: {{ .Values.database.user | quote }}
+            - name: MYSQL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "footballhub.dbSecretName" . }}
+                  key: MYSQL_PASSWORD
+          readinessProbe:
+            exec:
+              command: ["sh", "-c", "mysqladmin ping -h127.0.0.1 -uroot -p\"$MYSQL_ROOT_PASSWORD\""]
+            initialDelaySeconds: 10
+            periodSeconds: 5
+            timeoutSeconds: 3
+          resources:
+            {{- toYaml .Values.mysql.resources | nindent 12 }}
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/mysql
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        {{- with .Values.mysql.storage.storageClassName }}
+        storageClassName: {{ . | quote }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.mysql.storage.size | quote }}
+{{- end }}

--- a/deploy/helm/footballhub/values.yaml
+++ b/deploy/helm/footballhub/values.yaml
@@ -1,0 +1,93 @@
+# Default values for the footballhub chart.
+
+nameOverride: ""
+fullnameOverride: ""
+
+image:
+  registry: ghcr.io
+  owner: adrianoggm
+  pullPolicy: IfNotPresent
+  # Defaults to the chart appVersion when tag is empty.
+  tag: ""
+
+backend:
+  image:
+    repository: footballhubmanager-backend
+  replicas: 2
+  containerPort: 8000
+  resources:
+    requests: { cpu: 100m, memory: 256Mi }
+    limits: { cpu: "1", memory: 512Mi }
+
+frontend:
+  image:
+    repository: footballhubmanager-frontend
+  replicas: 2
+  containerPort: 8080
+  resources:
+    requests: { cpu: 25m, memory: 64Mi }
+    limits: { cpu: 250m, memory: 128Mi }
+
+# Non-secret application configuration (rendered into a ConfigMap, shared by the
+# backend Deployment and the migration Job).
+app:
+  env: production
+  allowedHosts: "" # comma-separated; e.g. "api.example.com"
+  corsAllowedOrigins: "" # e.g. "https://app.example.com"
+  linkTokenTtlSeconds: 86400
+  sessionTtlSeconds: 3600
+  # Refuse to start the API if the schema has pending migrations (fail fast in
+  # prod). Disable for the in-cluster first-install two-step (see NOTES.txt).
+  strictMigrationCheck: true
+  extraEnv: {} # arbitrary extra non-secret env: KEY: value
+
+# Schema migrations run as a Helm pre-install,pre-upgrade hook Job (backend image,
+# args below). Helm blocks the rollout until it succeeds, so the API never serves
+# against an un-migrated schema.
+migrations:
+  enabled: true
+  # Use ["stamp"] (or ["stamp","<N>"]) for the FIRST deploy against an existing
+  # database to baseline it without re-running present migrations; ["migrate"]
+  # thereafter. See docs/deployment.md.
+  args: ["migrate"]
+  resources:
+    requests: { cpu: 100m, memory: 256Mi }
+    limits: { cpu: "1", memory: 512Mi }
+
+# Database connection. Two modes via `mysql.enabled`:
+#   true  -> an in-cluster MySQL StatefulSet (good for dev / small setups)
+#   false -> an external/managed database (recommended for production)
+database:
+  name: footballhub
+  user: footballuser
+  port: 3306
+  provider: mysql+pymysql
+  # Secret + key holding DB_PASSWORD. Leave existingSecret empty to let the chart
+  # create one from the password values below.
+  existingSecret: ""
+  passwordSecretKey: DB_PASSWORD
+
+mysql:
+  enabled: true
+  image: mysql:8.0
+  # Used only when mysql.enabled and database.existingSecret is empty.
+  rootPassword: changeme-root
+  password: changeme
+  storage:
+    size: 8Gi
+    storageClassName: "" # "" uses the cluster default
+  resources:
+    requests: { cpu: 250m, memory: 512Mi }
+    limits: { cpu: "1", memory: 1Gi }
+
+externalDatabase:
+  # Used only when mysql.enabled is false.
+  host: ""
+  # Password comes from database.existingSecret (recommended) or mysql.password.
+
+ingress:
+  enabled: true
+  className: ""
+  host: footballhub.local
+  annotations: {}
+  tls: [] # e.g. [{ secretName: footballhub-tls, hosts: [app.example.com] }]

--- a/docker/docker-compose.ci.yml
+++ b/docker/docker-compose.ci.yml
@@ -20,8 +20,9 @@ services:
 
   backend:
     build:
-      context: ../backend
-      dockerfile: docker/Dockerfile
+      # Repo root: the image bundles app code AND versioning/sql migrations.
+      context: ..
+      dockerfile: backend/docker/Dockerfile
     depends_on:
       mysql:
         condition: service_healthy

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -3,6 +3,35 @@
 Target: **Kubernetes** (future scaling). Registry: **GHCR**. Images are built and
 published on a **semver tag** (`vX.Y.Z`).
 
+## Flow overview
+
+```mermaid
+sequenceDiagram
+    actor Dev as Developer
+    participant GH as GitHub Actions
+    participant GHCR
+    actor Ops as Operator
+    participant Helm
+    participant Job as Migrate Job
+    participant DB as MySQL
+    participant API as Backend
+
+    Dev->>GH: git push tag vX.Y.Z
+    GH->>GHCR: build & push backend + frontend images
+    Ops->>Helm: helm upgrade --install (image.tag=X.Y.Z)
+    Helm->>Job: pre-upgrade hook, run "migrate"
+    Job->>DB: wait for DB, apply pending vN.sql
+    DB-->>Job: schema at head
+    Job-->>Helm: success (rollout blocked if it fails)
+    Helm->>API: roll out backend + frontend
+    API->>DB: startup check (STRICT): any pending?
+    API-->>Ops: serving via Ingress (/api to backend, / to frontend)
+```
+
+The migration Job runs **before** the API rolls out and Helm blocks the release
+until it succeeds, so the backend never serves against a stale schema (and refuses
+to boot if it somehow would).
+
 ## Images
 
 `./.github/workflows/release.yml` builds and pushes two images when you push a tag:
@@ -37,6 +66,19 @@ tracks applied versions in `schema_migrations` and applies only the pending ones
 > The MySQL docker-entrypoint init (`actual.sql`) **only runs on an empty data
 > volume**, so it cannot evolve a database that already holds production data.
 > Production always evolves through the **runner**, never through the init script.
+
+```mermaid
+flowchart TD
+    Start([Deploy a release]) --> Q{"Database already<br/>has data?"}
+    Q -->|No / fresh DB| M["migrate: apply v1..vN in order"]
+    Q -->|Yes, first time on the runner| S["stamp once: baseline to head"]
+    S --> L[Later releases run migrate]
+    M --> T[("schema_migrations<br/>updated")]
+    L --> T
+    T --> G{"Backend startup:<br/>pending migrations?"}
+    G -->|None| OK[API serves traffic]
+    G -->|Pending and STRICT| Fail[Fail fast at boot]
+```
 
 ### Commands (image entrypoint, or `just` locally)
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,94 @@
+# Deployment & image generation
+
+Target: **Kubernetes** (future scaling). Registry: **GHCR**. Images are built and
+published on a **semver tag** (`vX.Y.Z`).
+
+## Images
+
+`./.github/workflows/release.yml` builds and pushes two images when you push a tag:
+
+```bash
+git tag v1.2.0
+git push origin v1.2.0
+```
+
+| Image | Build context | Dockerfile |
+|-------|---------------|------------|
+| `ghcr.io/adrianoggm/footballhubmanager-backend` | repo root | `backend/docker/Dockerfile` |
+| `ghcr.io/adrianoggm/footballhubmanager-frontend` | `frontend/` | `frontend/Dockerfile` |
+
+Tags produced per release: `{{version}}` (e.g. `1.2.0`), `{{major}}.{{minor}}` (`1.2`),
+`sha-<gitsha>`, and `latest`.
+
+- **Backend** is built from the **repository root** so the image bundles both the
+  app code (`backend/src`) and the SQL migrations (`versioning/sql`) the runner
+  applies. It is a single image with multiple roles via its entrypoint:
+  `serve` (default), `migrate`, `stamp [N]`, `status`.
+- **Frontend** is a static SPA served by nginx on `:8080`. It is backend-agnostic;
+  the Ingress routes `/api` to the backend Service and everything else to the
+  frontend (the SPA calls `/api/v1/...` relative to its own origin).
+
+## Database migrations (the production flow)
+
+There is **no Alembic**. The schema is a forward-only series of
+`versioning/sql/versions/vN.sql` files. The runner (`backend/src/db_migrations`)
+tracks applied versions in `schema_migrations` and applies only the pending ones.
+
+> The MySQL docker-entrypoint init (`actual.sql`) **only runs on an empty data
+> volume**, so it cannot evolve a database that already holds production data.
+> Production always evolves through the **runner**, never through the init script.
+
+### Commands (image entrypoint, or `just` locally)
+
+| Action | In a container | Locally |
+|--------|----------------|---------|
+| Show applied/pending | `status` | `just db-status` |
+| Apply pending | `migrate` | `just db-migrate` |
+| Baseline existing DB | `stamp [N]` | `just db-stamp [N]` |
+
+### First rollout against an EXISTING production database
+
+The current prod DB already has data and a schema (created from `actual.sql` and/or
+manual `vN.sql`). Running `migrate` blindly would try to re-apply versions that are
+physically present and fail. Do this **once**:
+
+1. Back up the database (snapshot / `mysqldump`).
+2. Baseline it so the runner knows what is already there:
+   - If the schema matches the current head, `stamp` everything: `stamp`.
+   - If it is at an older point, cap it: `stamp 9` (marks v1–v9 applied).
+3. From then on, every deploy runs `migrate`, which applies only newer versions.
+
+### Fresh database (new environment, CI, dev)
+
+Either works:
+- Let the runner build it from scratch: `migrate` applies `v1..vN` in order
+  (`v1.sql` is the full base schema), **or**
+- Use the fast init (`actual.sql` on an empty volume) and then `stamp` so the
+  runner is in sync.
+
+### Authoring a new migration
+
+1. Add `versioning/sql/versions/vN.sql` (next number) with the `ALTER`/`CREATE`.
+2. Add the same change to `versioning/sql/actual.sql` (keeps the fast-init/dev path current).
+3. Update the relevant SQLAlchemy entity.
+4. Do **not** self-insert into `schema_migrations` in new files — the runner records
+   each applied version (older files v1–v8 self-record; the runner upserts idempotently).
+5. Prefer idempotent DDL where practical. Note: MySQL auto-commits per DDL statement,
+   so a multi-statement migration that fails midway cannot be fully rolled back —
+   fix forward.
+
+## Kubernetes wiring (next increment)
+
+Run the migration as a **one-shot Job that completes before the API serves traffic**,
+using the backend image with args `["migrate"]`:
+
+- **Helm:** a Job annotated as a `pre-install,pre-upgrade` hook (recommended) — Helm
+  blocks the rollout until it succeeds.
+- **Plain manifests:** a `Job` gated by your deploy tooling, or an `initContainer` on
+  the backend Deployment that runs `migrate` before the `serve` container starts.
+
+The backend Deployment runs the default `serve`; the frontend Deployment serves nginx;
+an Ingress maps `/api` → backend Service and `/` → frontend Service.
+
+> The Helm chart (Deployments, Services, Ingress, the migrate hook Job, Secrets/Config)
+> is the next step and depends on where MySQL lives (managed vs in-cluster).

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,20 @@
+# Multi-stage: build the Vite bundle with Node, then serve the static files with
+# nginx. Build context is frontend/.
+#   docker build -f frontend/Dockerfile -t <img> frontend
+FROM node:20-alpine AS build
+
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+
+FROM nginx:1.27-alpine AS runtime
+
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=build /app/dist /usr/share/nginx/html
+
+EXPOSE 8080
+
+# Serves a static SPA only. API routing (/api -> backend) is handled by the
+# Kubernetes Ingress, so the frontend image stays backend-agnostic.

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,0 +1,25 @@
+server {
+    listen 8080;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # Hashed build assets can be cached forever.
+    location /assets/ {
+        try_files $uri =404;
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+    }
+
+    # SPA fallback: client-side routes (e.g. /claim/<token>, /app/...) resolve to
+    # index.html so React Router can take over.
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    # index.html itself must never be cached, or clients pin a stale bundle.
+    location = /index.html {
+        add_header Cache-Control "no-cache";
+    }
+}

--- a/justfile
+++ b/justfile
@@ -35,6 +35,19 @@ db-reset:
 db-logs:
     docker compose -f docker/docker-compose.yml logs -f mysql
 
+# Show which schema migrations are applied vs pending.
+db-status:
+    {{venv_python}} backend/manage.py status
+
+# Apply all pending migrations (versioning/sql/versions/vN.sql) to the configured DB.
+db-migrate:
+    {{venv_python}} backend/manage.py migrate
+
+# Baseline an existing DB: mark migrations as applied WITHOUT running them.
+# Optionally cap with a version, e.g. `just db-stamp 11`.
+db-stamp version="":
+    {{venv_python}} backend/manage.py stamp {{version}}
+
 backend port="8000" host="127.0.0.1":
     {{venv_python}} -m uvicorn src.main:app --app-dir backend --host {{host}} --port {{port}} --reload
 

--- a/versioning/sql/actual.sql
+++ b/versioning/sql/actual.sql
@@ -364,6 +364,19 @@ on duplicate key update name=values(name);
 
 set foreign_key_checks = 1;
 
-insert into schema_migrations (version, description, success)
-values ('1', 'init schema (lowercase tables)', 1)
+-- actual.sql is the cumulative head schema, so it records EVERY version as
+-- applied. A database initialized from this file is already at head and the
+-- migration runner will treat all versions as done (no re-apply, no stamp step).
+insert into schema_migrations (version, description, success) values
+  ('1', 'init schema (lowercase tables)', 1),
+  ('2', 'pena roles normalized', 1),
+  ('3', 'season player role/position snapshot', 1),
+  ('4', 'season player role label snapshot', 1),
+  ('5', 'pena accountability', 1),
+  ('6', 'match timeline tracking', 1),
+  ('7', 'match event value delta', 1),
+  ('8', 'football match official status and lineup audit', 1),
+  ('9', 'football match clock pause', 1),
+  ('10', 'football match goalkeeper rotation', 1),
+  ('11', 'pena link token player claim', 1)
 on duplicate key update description=values(description), success=values(success);


### PR DESCRIPTION
#99 
## Summary

Adds the deployment story for the project: published container images, a forward-only
database migration runner, and a Helm chart to run on Kubernetes — with the migration
flow designed for a database that **already holds production data**.

Closes #99.

This PR is deployment-only; it does not touch product/feature code.

## What's included

### 1. Database migration runner (no Alembic)
- `backend/src/db_migrations` applies `versioning/sql/versions/vN.sql` in order, tracking
  applied versions in `schema_migrations` and running only the pending ones.
- Commands via the backend image entrypoint (or `just` locally): `status`, `migrate`,
  `stamp [N]`.
- **Existing production DB:** `stamp` once to baseline (mark present versions applied
  without re-running them), then `migrate` on every release.
- `versioning/sql/actual.sql` now records all current versions, so a fresh DB is "at head"
  with no manual stamp.
- Replaces the ad-hoc `ALTER TABLE`-on-startup hack in `main.py` with a read-only check
  that fails fast when `STRICT_MIGRATION_CHECK=true` (prod default) and warns otherwise.

### 2. Images (published to GHCR on a semver tag)
- `.github/workflows/release.yml`: pushing `vX.Y.Z` builds & pushes both images
  (`backend`, `frontend`) to `ghcr.io/adrianoggm/...` tagged `X.Y.Z` / `X.Y` / `sha-…` / `latest`.
- **Backend** built from the repo root so the image bundles app code + migration SQL;
  single image, multiple roles (`serve`/`migrate`/`stamp`/`status`); non-root; healthcheck.
- **Frontend** multi-stage Node→nginx static SPA (SPA fallback); backend-agnostic.
- `docker/docker-compose.ci.yml` updated to the repo-root backend build context.

### 3. Helm chart (`deploy/helm/footballhub`)
- Parametrized database via `mysql.enabled`: in-cluster StatefulSet (dev) or external
  managed DB (prod, `externalDatabase` + `database.existingSecret`).
- Migrations run as a **`pre-install,pre-upgrade` hook Job** (backend image, `migrate`),
  so Helm blocks the rollout until the schema is current — the API never serves against
  a stale schema.
- Backend/Frontend Deployments + Services + Ingress (`/api` → backend, `/` → frontend).

### 4. Docs
- `docs/deployment.md` + a Deployment section in `README.md`, both with Mermaid diagrams
  (release→deploy sequence and the migration decision flow).

## Testing
- Backend: **727 unit tests** pass, ruff clean (adds runner + startup-check tests).
- Backend image builds; migrations bundled and discovered at `/app/versioning/sql/versions`.
- `helm lint` passes; chart renders in both in-cluster and external-DB modes.

## Notes / follow-ups
- First `helm install` with **in-cluster** MySQL needs `--set migrations.enabled=false
  --set app.strictMigrationCheck=false`, then `helm upgrade` (Helm runs hooks before the
  StatefulSet exists). Production with a managed DB has no such caveat.
- GHCR packages are private by default — make them public or configure an imagePullSecret.
- A CD job (auto-deploy after release) is intentionally left out until cluster access exists.
