### PR TITLE
Develop

### DIFF
--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -240,4 +240,8 @@ if __name__ == "__main__":
         port=app_config.APP_PORT,
         reload=app_config.APP_RELOAD,
         log_level="info",
+        # TLS terminates at the ingress; trust its forwarded headers so the app
+        # sees the real scheme (https) and client IP instead of the proxy's.
+        proxy_headers=True,
+        forwarded_allow_ips=os.getenv("FORWARDED_ALLOW_IPS", "*"),
     )

--- a/deploy/helm/footballhub/examples/clusterissuer-letsencrypt-prod.yaml
+++ b/deploy/helm/footballhub/examples/clusterissuer-letsencrypt-prod.yaml
@@ -1,0 +1,21 @@
+# cert-manager ClusterIssuer for Let's Encrypt (production).
+# Apply ONCE per cluster, before deploying with ingress.tls.clusterIssuer set:
+#   kubectl apply -f clusterissuer-letsencrypt-prod.yaml
+#   kubectl get clusterissuer letsencrypt-prod   # READY=True
+#
+# Tip: validate the flow against staging first (much higher rate limits) by
+# duplicating this with name letsencrypt-staging and the acme-staging server URL.
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-prod
+spec:
+  acme:
+    server: https://acme-v02.api.letsencrypt.org/directory
+    email: you@example.com # <-- expiry notices go here
+    privateKeySecretRef:
+      name: letsencrypt-prod-account-key
+    solvers:
+      - http01:
+          ingress:
+            class: nginx

--- a/deploy/helm/footballhub/examples/values-prod.yaml
+++ b/deploy/helm/footballhub/examples/values-prod.yaml
@@ -1,0 +1,39 @@
+# Example production values for a single-node VPS (k3s) with HTTPS.
+# Copy, edit the host/passwords, and pass with: helm upgrade -f values-prod.yaml
+#
+# TLS bring-up is two-step (see docs/vps-deployment.md): deploy first with
+# forceHttpsRedirect=false, wait for the cert to be Ready, then flip it on.
+
+backend:
+  replicas: 1 # single node; bump once you have more nodes
+
+frontend:
+  replicas: 1
+
+app:
+  env: production
+  allowedHosts: "app.example.com" # <-- your domain
+  corsAllowedOrigins: "https://app.example.com" # <-- your domain, https
+  strictMigrationCheck: true
+
+# In-cluster MySQL is fine for a small single-node setup. For real production
+# prefer an external/managed DB (set mysql.enabled=false + externalDatabase.host).
+mysql:
+  enabled: true
+  rootPassword: "CHANGE-ME-root" # <-- change
+  password: "CHANGE-ME" # <-- change
+  storage:
+    size: 8Gi
+    storageClassName: "local-path" # k3s default storage class
+
+ingress:
+  enabled: true
+  className: nginx
+  host: app.example.com # <-- your domain
+  tls:
+    enabled: true
+    secretName: footballhub-tls
+    clusterIssuer: letsencrypt-prod
+  forceHttpsRedirect: false # turn ON after the cert is Ready (avoids redirect loop)
+  hsts:
+    enabled: false # turn ON once HTTPS is stable

--- a/deploy/helm/footballhub/templates/NOTES.txt
+++ b/deploy/helm/footballhub/templates/NOTES.txt
@@ -22,7 +22,14 @@ Migrations: {{ if .Values.migrations.enabled }}run as a pre-install/pre-upgrade 
   (Production with an external/managed DB does not have this caveat.)
 {{- end }}
 
-{{- if not .Values.ingress.enabled }}
+{{- if .Values.ingress.enabled }}
+
+App URL: {{ if .Values.ingress.tls.enabled }}https{{ else }}http{{ end }}://{{ .Values.ingress.host }}/ (API under /api)
+{{- if not .Values.ingress.tls.enabled }}
+  TLS is OFF. To enable HTTPS, set ingress.tls.enabled=true (+ ingress.tls.clusterIssuer
+  for cert-manager). See docs/deployment.md → HTTPS / TLS.
+{{- end }}
+{{- else }}
 
 Ingress is disabled — expose the services yourself (e.g. kubectl port-forward
 svc/{{ include "footballhub.fullname" . }}-frontend 8080:80).

--- a/deploy/helm/footballhub/templates/ingress.yaml
+++ b/deploy/helm/footballhub/templates/ingress.yaml
@@ -1,21 +1,36 @@
 {{- if .Values.ingress.enabled }}
+{{- $tls := .Values.ingress.tls }}
+{{- $ann := deepCopy (default dict .Values.ingress.annotations) }}
+{{- if and $tls.enabled $tls.clusterIssuer }}
+{{- $ann = set $ann "cert-manager.io/cluster-issuer" $tls.clusterIssuer }}
+{{- end }}
+{{- if .Values.ingress.forceHttpsRedirect }}
+{{- $ann = set $ann "nginx.ingress.kubernetes.io/ssl-redirect" "true" }}
+{{- $ann = set $ann "nginx.ingress.kubernetes.io/force-ssl-redirect" "true" }}
+{{- end }}
+{{- if .Values.ingress.hsts.enabled }}
+{{- $hstsHeader := printf "Strict-Transport-Security: max-age=%d%s" (int64 .Values.ingress.hsts.maxAge) (ternary "; includeSubDomains" "" .Values.ingress.hsts.includeSubDomains) }}
+{{- $ann = set $ann "nginx.ingress.kubernetes.io/configuration-snippet" (printf "more_set_headers \"%s\";\n" $hstsHeader) }}
+{{- end }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ include "footballhub.fullname" . }}
   labels:
     {{- include "footballhub.labels" . | nindent 4 }}
-  {{- with .Values.ingress.annotations }}
+  {{- if $ann }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+    {{- toYaml $ann | nindent 4 }}
   {{- end }}
 spec:
   {{- with .Values.ingress.className }}
   ingressClassName: {{ . }}
   {{- end }}
-  {{- with .Values.ingress.tls }}
+  {{- if $tls.enabled }}
   tls:
-    {{- toYaml . | nindent 4 }}
+    - hosts:
+        - {{ .Values.ingress.host | quote }}
+      secretName: {{ $tls.secretName | quote }}
   {{- end }}
   rules:
     - host: {{ .Values.ingress.host | quote }}

--- a/deploy/helm/footballhub/values.yaml
+++ b/deploy/helm/footballhub/values.yaml
@@ -90,4 +90,24 @@ ingress:
   className: ""
   host: footballhub.local
   annotations: {}
-  tls: [] # e.g. [{ secretName: footballhub-tls, hosts: [app.example.com] }]
+  # TLS terminates here at the ingress; the backend and frontend stay plain HTTP
+  # inside the cluster. uvicorn trusts X-Forwarded-Proto, so the app still sees
+  # the request as https.
+  tls:
+    enabled: false
+    # Secret holding the cert/key for `host`. With cert-manager (clusterIssuer
+    # set below) the cert is issued INTO this secret automatically; otherwise
+    # create it yourself: kubectl create secret tls <name> --cert=... --key=...
+    secretName: footballhub-tls
+    # cert-manager ClusterIssuer (e.g. "letsencrypt-prod"). When set, the chart
+    # adds the cert-manager.io/cluster-issuer annotation and the cert is
+    # auto-issued and auto-renewed. Requires cert-manager installed in-cluster.
+    clusterIssuer: ""
+  # Redirect HTTP -> HTTPS at the ingress (nginx-ingress annotations). Turn on
+  # once TLS works to avoid a redirect loop before the cert is ready.
+  forceHttpsRedirect: false
+  # Strict-Transport-Security header. Only enable once HTTPS is stable.
+  hsts:
+    enabled: false
+    maxAge: 31536000 # 1 year, in seconds
+    includeSubDomains: true

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -134,3 +134,68 @@ an Ingress maps `/api` → backend Service and `/` → frontend Service.
 
 > The Helm chart (Deployments, Services, Ingress, the migrate hook Job, Secrets/Config)
 > is the next step and depends on where MySQL lives (managed vs in-cluster).
+
+## HTTPS / TLS
+
+TLS terminates **at the Ingress**. Backend and frontend stay plain HTTP inside the
+cluster (backend on `:8000`, nginx on `:8080`); only the ingress speaks HTTPS to the
+internet. The pieces that make this work:
+
+- **Backend trusts the proxy.** uvicorn runs with `proxy_headers=True` and
+  `forwarded_allow_ips` (override via `FORWARDED_ALLOW_IPS`, default `*`). It reads
+  `X-Forwarded-Proto`/`-For` from the ingress, so `request.url.scheme` is `https` and
+  Swagger/redoc and any generated URLs use the right scheme. `*` is safe here because
+  the only thing that can reach the pod is the in-cluster ingress.
+- **Frontend uses a relative API base** (`VITE_API_BASE_URL` defaults to `""`), so the
+  SPA calls `/api/...` on its own origin and automatically inherits `https://`. No
+  mixed content, and the PWA service worker (which *requires* HTTPS in production) works.
+- **Auth is Bearer-token, not cookies** — there are no `Secure`/`SameSite` cookie flags
+  to set.
+
+### Enable TLS with cert-manager (recommended)
+
+Requires [cert-manager](https://cert-manager.io/) installed and a `ClusterIssuer`
+(e.g. `letsencrypt-prod`). The chart adds the `cert-manager.io/cluster-issuer`
+annotation; cert-manager issues and renews the cert into `ingress.tls.secretName`.
+
+```yaml
+# values-prod.yaml (excerpt)
+ingress:
+  enabled: true
+  className: nginx
+  host: app.example.com
+  tls:
+    enabled: true
+    secretName: footballhub-tls
+    clusterIssuer: letsencrypt-prod
+  forceHttpsRedirect: true   # turn on AFTER the cert is issued (avoids redirect loop)
+  hsts:
+    enabled: true            # turn on once HTTPS is stable
+
+app:
+  env: production
+  allowedHosts: "app.example.com"
+  corsAllowedOrigins: "https://app.example.com"
+```
+
+```bash
+helm upgrade --install footballhub ./deploy/helm/footballhub -f values-prod.yaml
+```
+
+Bring TLS up in two steps to avoid locking yourself out while the cert is pending:
+first deploy with `tls.enabled=true` but `forceHttpsRedirect=false`; once
+`kubectl get certificate` shows `Ready=True`, enable `forceHttpsRedirect` (and `hsts`).
+
+### Enable TLS with a pre-provisioned certificate
+
+Skip `clusterIssuer` and create the secret yourself (corporate CA, wildcard, etc.):
+
+```bash
+kubectl create secret tls footballhub-tls --cert=tls.crt --key=tls.key
+helm upgrade --install footballhub ./deploy/helm/footballhub \
+  --set ingress.tls.enabled=true --set ingress.host=app.example.com
+```
+
+> The redirect/HSTS annotations are written in the `nginx.ingress.kubernetes.io/*`
+> form. On a different ingress controller, set the equivalent via `ingress.annotations`
+> and leave `forceHttpsRedirect`/`hsts` off.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -137,6 +137,9 @@ an Ingress maps `/api` → backend Service and `/` → frontend Service.
 
 ## HTTPS / TLS
 
+> For an end-to-end, copy-paste runbook on a single cheap VPS (k3s + ingress-nginx +
+> cert-manager + this chart), see [vps-deployment.md](vps-deployment.md).
+
 TLS terminates **at the Ingress**. Backend and frontend stay plain HTTP inside the
 cluster (backend on `:8000`, nginx on `:8080`); only the ingress speaks HTTPS to the
 internet. The pieces that make this work:

--- a/docs/vps-deployment.md
+++ b/docs/vps-deployment.md
@@ -1,0 +1,194 @@
+# Deploying on a VPS (k3s + HTTPS)
+
+A complete, copy-paste runbook to deploy footballhubmanager on a single cheap VPS
+using **k3s** (lightweight Kubernetes), **ingress-nginx**, **cert-manager**, and the
+Helm chart in `deploy/helm/footballhub`. Result: the app served at
+`https://app.example.com` with an auto-renewing Let's Encrypt certificate.
+
+This is the operator counterpart to the TLS model documented in
+[deployment.md](deployment.md#https--tls). Example files referenced here live in
+[`deploy/helm/footballhub/examples/`](../deploy/helm/footballhub/examples/).
+
+## 0. What you need first
+
+- A **VPS** with a **dedicated public IPv4** and Ubuntu 22.04/24.04
+  (e.g. Hetzner CX22, ~5 €/mo — 2 vCPU / 4 GB is comfortable for backend + MySQL +
+  frontend on one node).
+- A **domain** (e.g. Cloudflare Registrar / Namecheap / Porkbun).
+- SSH access to the VPS as root (or a sudo user).
+
+> Sizing: with in-cluster MySQL, give the node at least 4 GB RAM. 2 GB works but is
+> tight once MySQL warms up.
+
+## 1. Point DNS at the VPS
+
+Create a DNS **A record** for your host pointing at the VPS public IP:
+
+```
+app.example.com.   A   <VPS_PUBLIC_IP>
+```
+
+Verify it has propagated before requesting a certificate (Let's Encrypt validates
+over HTTP, so the name must already resolve to this box):
+
+```bash
+dig +short app.example.com   # must print <VPS_PUBLIC_IP>
+```
+
+## 2. Harden the VPS (quick pass)
+
+```bash
+# as root on the VPS
+apt update && apt upgrade -y
+# Allow SSH + HTTP + HTTPS only
+ufw allow OpenSSH
+ufw allow 80/tcp
+ufw allow 443/tcp
+ufw allow 6443/tcp   # k3s API (restrict to your IP if possible)
+ufw --force enable
+```
+
+## 3. Install k3s
+
+k3s ships with Traefik by default; we disable it because the chart's annotations
+target **ingress-nginx**.
+
+```bash
+curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="--disable traefik" sh -
+
+# kubectl is installed as part of k3s; its kubeconfig is here:
+export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
+kubectl get nodes        # node should be Ready
+```
+
+To run `kubectl`/`helm` from your laptop instead, copy `/etc/rancher/k3s/k3s.yaml`,
+replace `127.0.0.1` with the VPS public IP, and point `KUBECONFIG` at it.
+
+Install Helm (on whichever machine runs the deploy):
+
+```bash
+curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+```
+
+## 4. Install ingress-nginx + cert-manager
+
+```bash
+# ingress-nginx
+helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
+helm repo update
+helm install ingress-nginx ingress-nginx/ingress-nginx \
+  -n ingress-nginx --create-namespace
+
+# cert-manager
+helm repo add jetstack https://charts.jetstack.io
+helm repo update
+helm install cert-manager jetstack/cert-manager \
+  -n cert-manager --create-namespace --set crds.enabled=true
+
+kubectl get pods -n ingress-nginx
+kubectl get pods -n cert-manager   # all Running before continuing
+```
+
+On a single-node k3s the ingress-nginx Service is usually exposed via the node's
+ports 80/443 directly. Confirm traffic reaches it:
+
+```bash
+curl -I http://app.example.com/   # 404 from nginx is fine — it means it's reachable
+```
+
+## 5. Create the Let's Encrypt ClusterIssuer (once)
+
+Edit the email, then apply:
+
+```bash
+# edit deploy/helm/footballhub/examples/clusterissuer-letsencrypt-prod.yaml (email)
+kubectl apply -f deploy/helm/footballhub/examples/clusterissuer-letsencrypt-prod.yaml
+kubectl get clusterissuer letsencrypt-prod   # READY=True
+```
+
+> First time? Point `spec.acme.server` at the **staging** endpoint to avoid burning
+> Let's Encrypt rate limits while you debug. Switch to prod once the flow works.
+
+## 6. Deploy the app (HTTPS, step 1 of 2)
+
+Copy and edit the example values (domain + DB passwords):
+
+```bash
+cp deploy/helm/footballhub/examples/values-prod.yaml /tmp/values-prod.yaml
+# edit: ingress.host, app.allowedHosts, app.corsAllowedOrigins, mysql passwords
+```
+
+### In-cluster MySQL first-install caveat
+
+The migration Job runs as a Helm **pre-install hook**, but on a *fresh* install the
+in-cluster MySQL StatefulSet isn't up yet, so the hook would time out. So the very
+first install disables migrations, then a follow-up upgrade runs them (see
+[NOTES.txt](../deploy/helm/footballhub/templates/NOTES.txt)). With an **external DB**
+this caveat does not apply — skip straight to the normal install.
+
+```bash
+# First install (in-cluster MySQL): migrations off, redirect off
+helm install footballhub ./deploy/helm/footballhub -f /tmp/values-prod.yaml \
+  --set migrations.enabled=false --set app.strictMigrationCheck=false
+
+# Now MySQL is up — upgrade to run migrations
+helm upgrade footballhub ./deploy/helm/footballhub -f /tmp/values-prod.yaml
+```
+
+(For an external/managed DB: just `helm install footballhub ./deploy/helm/footballhub -f /tmp/values-prod.yaml`.)
+
+## 7. Wait for the certificate
+
+```bash
+kubectl get certificate            # wait for footballhub-tls -> READY=True
+kubectl describe certificate footballhub-tls   # if it stalls, read the events
+kubectl get challenges             # HTTP-01 challenges should resolve & disappear
+```
+
+Common stalls: DNS not resolving to the VPS yet, port 80 blocked (cert-manager's
+HTTP-01 needs inbound :80), or the wrong `ingress.className`.
+
+## 8. Turn on HTTPS redirect + HSTS (step 2 of 2)
+
+Once the cert is `Ready`:
+
+```bash
+helm upgrade footballhub ./deploy/helm/footballhub -f /tmp/values-prod.yaml \
+  --set ingress.forceHttpsRedirect=true \
+  --set ingress.hsts.enabled=true
+```
+
+(Or set those two to `true` in your values file and `helm upgrade`.)
+
+## 9. Verify
+
+```bash
+curl -I http://app.example.com/     # 301/308 -> https
+curl -I https://app.example.com/    # 200 + Strict-Transport-Security header
+curl https://app.example.com/api/   # {"status":"ok","service":"FootballHubManager API"}
+```
+
+In a browser: valid padlock, app loads, and the PWA can install (the service worker
+requires HTTPS in production).
+
+## 10. Day-2 operations
+
+- **New release:** push a `vX.Y.Z` tag (CI builds images), then
+  `helm upgrade footballhub ./deploy/helm/footballhub -f /tmp/values-prod.yaml --set image.tag=X.Y.Z`.
+  The pre-upgrade migration Job applies pending `vN.sql` before the API rolls out.
+- **Cert renewal:** automatic via cert-manager (~30 days before expiry). Nothing to do.
+- **MySQL backups (you own these on a single VPS):** schedule a `mysqldump` to an
+  off-box bucket (Cloudflare R2 / Backblaze B2), e.g. a CronJob or host cron. A
+  single-node VPS has no HA — back up regularly.
+- **Logs:** `kubectl logs deploy/footballhub-backend`,
+  `kubectl logs job/<migrate-job>`.
+
+## Notes / limitations
+
+- **Single node = no high availability.** A reboot or disk failure takes the app
+  down. For real production move to a managed DB and/or multiple nodes, or a managed
+  Kubernetes (Hetzner, DigitalOcean ~12 $/mo per node).
+- The redirect/HSTS annotations are `nginx.ingress.kubernetes.io/*`. On a different
+  ingress controller, set equivalents via `ingress.annotations` and leave
+  `forceHttpsRedirect`/`hsts` off.
+- EU data residency (GDPR): pick an EU region for the VPS if you store personal data.


### PR DESCRIPTION
## Summary

Prepares the stack to serve over HTTPS. TLS terminates **at the Ingress**; the
backend (`:8000`) and frontend (`:8080`) stay plain HTTP inside the cluster — the
standard, low-risk model. **These changes do not turn HTTPS on by default**
(`ingress.tls.enabled` defaults to `false`), so behavior is unchanged until an
operator deploys with TLS values.

## What changed

**Backend** — `backend/src/main.py`
- uvicorn now runs with `proxy_headers=True` and `forwarded_allow_ips`
  (env `FORWARDED_ALLOW_IPS`, default `*`). It trusts the ingress's
  `X-Forwarded-Proto`/`-For`, so `request.url.scheme` is `https` and Swagger/redoc
  plus any generated URLs use the correct scheme. `*` is safe because only the
  in-cluster ingress can reach the pod.

**Helm chart** — `deploy/helm/footballhub`
- `values.yaml`: replaced the raw `tls: []` override with a structured block:
  `ingress.tls.{enabled,secretName,clusterIssuer}`, `ingress.forceHttpsRedirect`,
  and `ingress.hsts.{enabled,maxAge,includeSubDomains}`.
- `templates/ingress.yaml`: templates the `cert-manager.io/cluster-issuer`
  annotation, the nginx `ssl-redirect`/`force-ssl-redirect` annotations, an HSTS
  `configuration-snippet`, and the `tls:` block. All conditional — the default
  render (no TLS) is byte-for-byte unchanged.
- `templates/NOTES.txt`: post-install output now shows the correct `http`/`https`
  URL and nudges to enable TLS.

**Docs** — `docs/deployment.md`
- New **HTTPS / TLS** section: termination model, cert-manager example, the
  pre-provisioned-secret path, and the two-step bring-up.

## Why no app rewrite was needed
- Frontend already uses a **relative API base** (`VITE_API_BASE_URL` defaults to
  `""`) → it inherits `https://` automatically, no mixed content. The PWA service
  worker (which requires HTTPS in production) benefits directly.
- Auth is **Bearer-token, not cookies** → no `Secure`/`SameSite` flags to set.

## Validation
- `helm lint` clean; render verified both with and without TLS (no TLS → no
  annotations/tls block emitted; TLS on → correct cert-manager annotation,
  `max-age=31536000`, redirect annotations, tls block).
- Backend: **727 unit tests pass**; `ruff check` + `ruff format --check` clean.

## Operator notes (HTTPS rollout)

> ⚠️ This PR wires the chart for HTTPS but does **not** install cluster infra.
> Steps 1–3 below are one-time, cluster-level prerequisites (intentionally not in
> the chart). Steps 4–6 are the per-deploy flow this PR enables.

### Prerequisites (once per cluster)

1. **Ingress controller** (nginx — the chart's annotations are `nginx.ingress.kubernetes.io/*`):
   ```bash
   helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
   helm install ingress-nginx ingress-nginx/ingress-nginx \
     -n ingress-nginx --create-namespace
   ```
2. **cert-manager:**
   ```bash
   helm repo add jetstack https://charts.jetstack.io
   helm install cert-manager jetstack/cert-manager \
     -n cert-manager --create-namespace --set crds.enabled=true
   ```
3. **DNS:** point `app.example.com` at the ingress controller's external IP
   (`kubectl get svc -n ingress-nginx`). Without this, Let's Encrypt can't validate
   the domain and the certificate is never issued.

### Request certificates — create a ClusterIssuer (once per cluster)

Certificates are not requested by hand: cert-manager issues and **auto-renews** them
based on a `ClusterIssuer`.

```yaml
# clusterissuer-letsencrypt-prod.yaml
apiVersion: cert-manager.io/v1
kind: ClusterIssuer
metadata:
  name: letsencrypt-prod
spec:
  acme:
    server: https://acme-v02.api.letsencrypt.org/directory
    email: carmen.gil@innovasur.com        # expiry notices
    privateKeySecretRef:
      name: letsencrypt-prod-account-key
    solvers:
      - http01:
          ingress:
            class: nginx
```

```bash
kubectl apply -f clusterissuer-letsencrypt-prod.yaml
kubectl get clusterissuer letsencrypt-prod   # READY=True
```

> Tip: validate the flow against Let's Encrypt **staging** first
> (`https://acme-staging-v02.api.letsencrypt.org/directory`) — much higher rate
> limits; the cert is untrusted but proves the pipeline works. Then switch to prod.

### Deploy with HTTPS (two-step, avoids a redirect loop)

**Step 1 — deploy with TLS on but redirect off:**
```yaml
# values-prod.yaml
ingress:
  enabled: true
  className: nginx
  host: app.example.com
  tls:
    enabled: true
    secretName: footballhub-tls
    clusterIssuer: letsencrypt-prod
  forceHttpsRedirect: false   # not yet
  hsts:
    enabled: false            # not yet

app:
  env: production
  allowedHosts: "app.example.com"
  corsAllowedOrigins: "https://app.example.com"
```
```bash
helm upgrade --install footballhub ./deploy/helm/footballhub -f values-prod.yaml
```

**Step 2 — wait for the cert:**
```bash
kubectl get certificate            # wait for footballhub-tls READY=True
kubectl describe certificate footballhub-tls   # if it stalls
kubectl get challenges             # must resolve and disappear
```

**Step 3 — enable redirect + HSTS:**
```bash
helm upgrade footballhub ./deploy/helm/footballhub -f values-prod.yaml \
  --set ingress.forceHttpsRedirect=true \
  --set ingress.hsts.enabled=true
```

### Verify
```bash
curl -I http://app.example.com/     # 301/308 -> https
curl -I https://app.example.com/    # 200 + Strict-Transport-Security header
curl https://app.example.com/api/   # {"status":"ok",...}
```
Browser: valid padlock, and the PWA installs (service worker needs HTTPS).

### Task checklist

| # | Task | Scope |
|---|------|-------|
| 1 | Install nginx-ingress + cert-manager | once per cluster |
| 2 | Point domain DNS at the ingress IP | once per domain |
| 3 | Create the `ClusterIssuer` (`letsencrypt-prod`) | once per cluster |
| 4 | `helm upgrade` with `tls.enabled=true`, `forceHttpsRedirect=false` | per deploy |
| 5 | Wait for `certificate READY=True` | per deploy |
| 6 | `helm upgrade` enabling `forceHttpsRedirect` and `hsts` | per deploy |
| 7 | Verify with `curl` + browser | per deploy |

Only steps 1–3 live outside the chart (cluster infra, by design). Steps 4–6 are
fully wired by this PR.
