### PR TITLE
Task/#119+120

### DIFF
--- a/backend/config/.template.env
+++ b/backend/config/.template.env
@@ -3,6 +3,10 @@ APP_PORT=8000
 APP_RELOAD=true
 EXPOSE_INTERNAL_ERRORS=false
 LINK_TOKEN_TTL_SECONDS=86400
+# Required to create admin accounts via POST /api/v1/auth/admin/register.
+# Leave unset/empty to DISABLE admin registration (fail closed). Requests must
+# send it as the X-Admin-Registration-Secret header. Use a strong value in prod.
+ADMIN_REGISTRATION_SECRET=test-admin-registration-secret
 DB_HOST=localhost
 DB_PORT=3306
 DB_NAME=footballhub

--- a/backend/src/api/interface/controller/v1/auth_controller.py
+++ b/backend/src/api/interface/controller/v1/auth_controller.py
@@ -1,4 +1,6 @@
 import logging
+import os
+import secrets
 
 from api.dependencies.use_cases import (
     get_login_admin_use_case,
@@ -24,13 +26,39 @@ from core.application.commands.registration_commands import (
     RegisterAdminCommand,
     RegisterUserCommand,
 )
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Header, HTTPException, status
 from persistence.module import get_db
 from shared.application.bus.buses import CommandBus
 from sqlalchemy.orm import Session
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
+
+
+def require_admin_registration_secret(
+    x_admin_registration_secret: str | None = Header(
+        default=None, alias="X-Admin-Registration-Secret"
+    ),
+) -> None:
+    """Gate admin creation behind a server-side secret (fail closed).
+
+    Without ADMIN_REGISTRATION_SECRET set, admin registration is disabled, so the
+    endpoint can never be used for anonymous privilege escalation. Operators set the
+    secret to bootstrap/create admins.
+    """
+    expected = os.getenv("ADMIN_REGISTRATION_SECRET")
+    if not expected:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Admin registration is disabled",
+        )
+    if not x_admin_registration_secret or not secrets.compare_digest(
+        x_admin_registration_secret, expected
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Invalid admin registration secret",
+        )
 
 
 @router.post("/auth/login", response_model=LoginResponse)
@@ -119,7 +147,11 @@ def register_user(
     )
 
 
-@router.post("/auth/admin/register", response_model=LoginResponse)
+@router.post(
+    "/auth/admin/register",
+    response_model=LoginResponse,
+    dependencies=[Depends(require_admin_registration_secret)],
+)
 @map_exceptions
 def register_admin(
     payload: RegisterAdminRequest,

--- a/backend/src/api/interface/controller/v1/model/request/auth_request.py
+++ b/backend/src/api/interface/controller/v1/model/request/auth_request.py
@@ -6,9 +6,14 @@ class LoginRequest(BaseModel):
     password: str = Field(min_length=1)
 
 
+# Registration enforces a minimum password length; login does not, so accounts
+# created before this policy can still authenticate.
+MIN_PASSWORD_LENGTH = 12
+
+
 class RegisterUserRequest(BaseModel):
     username: str = Field(min_length=1)
-    password: str = Field(min_length=1)
+    password: str = Field(min_length=MIN_PASSWORD_LENGTH)
     name: str = Field(min_length=1)
     surname1: str = Field(min_length=1)
     surname2: str | None = None
@@ -17,5 +22,5 @@ class RegisterUserRequest(BaseModel):
 
 class RegisterAdminRequest(BaseModel):
     username: str = Field(min_length=1)
-    password: str = Field(min_length=1)
+    password: str = Field(min_length=MIN_PASSWORD_LENGTH)
     name: str = Field(min_length=1)

--- a/backend/tests/integration/test_api_flow.py
+++ b/backend/tests/integration/test_api_flow.py
@@ -7,13 +7,27 @@ from datetime import date, timedelta
 
 API_ROOT = os.getenv("TEST_API_ROOT", "http://127.0.0.1:8000/api")
 API_V1 = os.getenv("TEST_API_V1", "http://127.0.0.1:8000/api/v1")
+_ADMIN_REGISTRATION_HEADERS = {
+    "X-Admin-Registration-Secret": os.getenv(
+        "TEST_ADMIN_REGISTRATION_SECRET", "test-admin-registration-secret"
+    )
+}
 
 
-def _request(method: str, url: str, *, token: str | None = None, payload: dict | None = None):
+def _request(
+    method: str,
+    url: str,
+    *,
+    token: str | None = None,
+    payload: dict | None = None,
+    extra_headers: dict | None = None,
+):
     data = None
     headers = {"Content-Type": "application/json"}
     if token:
         headers["Authorization"] = f"Bearer {token}"
+    if extra_headers:
+        headers.update(extra_headers)
     if payload is not None:
         data = json.dumps(payload).encode("utf-8")
 
@@ -35,8 +49,13 @@ def _unique(prefix: str) -> str:
 
 def _register_admin():
     username = _unique("admin")
-    payload = {"username": username, "password": "secret123", "name": f"Pena {username}"}
-    status, data = _request("POST", f"{API_V1}/auth/admin/register", payload=payload)
+    payload = {"username": username, "password": "secret123456", "name": f"Pena {username}"}
+    status, data = _request(
+        "POST",
+        f"{API_V1}/auth/admin/register",
+        payload=payload,
+        extra_headers=_ADMIN_REGISTRATION_HEADERS,
+    )
     assert status == 200, data
     return data, payload
 
@@ -45,7 +64,7 @@ def _register_user():
     username = _unique("user")
     payload = {
         "username": username,
-        "password": "secret123",
+        "password": "secret123456",
         "name": "UserName",
         "surname1": "SurnameOne",
         "surname2": "SurnameTwo",

--- a/backend/tests/integration/test_link_token_concurrency.py
+++ b/backend/tests/integration/test_link_token_concurrency.py
@@ -6,13 +6,27 @@ import urllib.request
 import uuid
 
 API_V1 = os.getenv("TEST_API_V1", "http://127.0.0.1:8000/api/v1")
+_ADMIN_REGISTRATION_HEADERS = {
+    "X-Admin-Registration-Secret": os.getenv(
+        "TEST_ADMIN_REGISTRATION_SECRET", "test-admin-registration-secret"
+    )
+}
 
 
-def _request(method: str, url: str, *, token: str | None = None, payload: dict | None = None):
+def _request(
+    method: str,
+    url: str,
+    *,
+    token: str | None = None,
+    payload: dict | None = None,
+    extra_headers: dict | None = None,
+):
     data = None
     headers = {"Content-Type": "application/json"}
     if token:
         headers["Authorization"] = f"Bearer {token}"
+    if extra_headers:
+        headers.update(extra_headers)
     if payload is not None:
         data = json.dumps(payload).encode("utf-8")
 
@@ -34,8 +48,13 @@ def _unique(prefix: str) -> str:
 
 def _register_admin():
     username = _unique("admin")
-    payload = {"username": username, "password": "secret123", "name": f"Pena {username}"}
-    status, data = _request("POST", f"{API_V1}/auth/admin/register", payload=payload)
+    payload = {"username": username, "password": "secret123456", "name": f"Pena {username}"}
+    status, data = _request(
+        "POST",
+        f"{API_V1}/auth/admin/register",
+        payload=payload,
+        extra_headers=_ADMIN_REGISTRATION_HEADERS,
+    )
     assert status == 200, data
     return data
 
@@ -44,7 +63,7 @@ def _register_user():
     username = _unique("user")
     payload = {
         "username": username,
-        "password": "secret123",
+        "password": "secret123456",
         "name": "Concurrent",
         "surname1": "User",
         "surname2": None,

--- a/backend/tests/integration/test_pena_seasons_edges.py
+++ b/backend/tests/integration/test_pena_seasons_edges.py
@@ -5,13 +5,27 @@ import urllib.request
 import uuid
 
 API_V1 = os.getenv("TEST_API_V1", "http://127.0.0.1:8000/api/v1")
+_ADMIN_REGISTRATION_HEADERS = {
+    "X-Admin-Registration-Secret": os.getenv(
+        "TEST_ADMIN_REGISTRATION_SECRET", "test-admin-registration-secret"
+    )
+}
 
 
-def _request(method: str, url: str, *, token: str | None = None, payload: dict | None = None):
+def _request(
+    method: str,
+    url: str,
+    *,
+    token: str | None = None,
+    payload: dict | None = None,
+    extra_headers: dict | None = None,
+):
     data = None
     headers = {"Content-Type": "application/json"}
     if token:
         headers["Authorization"] = f"Bearer {token}"
+    if extra_headers:
+        headers.update(extra_headers)
     if payload is not None:
         data = json.dumps(payload).encode("utf-8")
 
@@ -33,8 +47,13 @@ def _unique(prefix: str) -> str:
 
 def _register_admin():
     username = _unique("admin")
-    payload = {"username": username, "password": "secret123", "name": f"Pena {username}"}
-    status, data = _request("POST", f"{API_V1}/auth/admin/register", payload=payload)
+    payload = {"username": username, "password": "secret123456", "name": f"Pena {username}"}
+    status, data = _request(
+        "POST",
+        f"{API_V1}/auth/admin/register",
+        payload=payload,
+        extra_headers=_ADMIN_REGISTRATION_HEADERS,
+    )
     assert status == 200, data
     return data
 
@@ -43,7 +62,7 @@ def _register_user():
     username = _unique("user")
     payload = {
         "username": username,
-        "password": "secret123",
+        "password": "secret123456",
         "name": "UserName",
         "surname1": "SurnameOne",
         "surname2": "SurnameTwo",

--- a/backend/tests/integration/test_season_competition_flow.py
+++ b/backend/tests/integration/test_season_competition_flow.py
@@ -7,13 +7,27 @@ import uuid
 from datetime import date, timedelta
 
 API_V1 = os.getenv("TEST_API_V1", "http://127.0.0.1:8000/api/v1")
+_ADMIN_REGISTRATION_HEADERS = {
+    "X-Admin-Registration-Secret": os.getenv(
+        "TEST_ADMIN_REGISTRATION_SECRET", "test-admin-registration-secret"
+    )
+}
 
 
-def _request(method: str, url: str, *, token: str | None = None, payload: dict | None = None):
+def _request(
+    method: str,
+    url: str,
+    *,
+    token: str | None = None,
+    payload: dict | None = None,
+    extra_headers: dict | None = None,
+):
     data = None
     headers = {"Content-Type": "application/json"}
     if token:
         headers["Authorization"] = f"Bearer {token}"
+    if extra_headers:
+        headers.update(extra_headers)
     if payload is not None:
         data = json.dumps(payload).encode("utf-8")
 
@@ -35,8 +49,13 @@ def _unique(prefix: str) -> str:
 
 def _register_admin():
     username = _unique("admin")
-    payload = {"username": username, "password": "secret123", "name": f"Pena {username}"}
-    status, data = _request("POST", f"{API_V1}/auth/admin/register", payload=payload)
+    payload = {"username": username, "password": "secret123456", "name": f"Pena {username}"}
+    status, data = _request(
+        "POST",
+        f"{API_V1}/auth/admin/register",
+        payload=payload,
+        extra_headers=_ADMIN_REGISTRATION_HEADERS,
+    )
     assert status == 200, data
     return data
 
@@ -45,7 +64,7 @@ def _register_user():
     username = _unique("user")
     payload = {
         "username": username,
-        "password": "secret123",
+        "password": "secret123456",
         "name": "UserName",
         "surname1": "SurnameOne",
         "surname2": "SurnameTwo",

--- a/backend/tests/test_auth_controller.py
+++ b/backend/tests/test_auth_controller.py
@@ -227,7 +227,7 @@ def test_register_user_returns_session_response(monkeypatch):
     response = auth_controller.register_user(
         RegisterUserRequest(
             username="u17",
-            password="secret",
+            password="secret-pass-123",
             name="Ana",
             surname1="Lopez",
             surname2=None,
@@ -266,7 +266,7 @@ def test_register_user_rolls_back_when_create_session_fails(monkeypatch):
         auth_controller.register_user(
             RegisterUserRequest(
                 username="u17",
-                password="secret",
+                password="secret-pass-123",
                 name="Ana",
                 surname1="Lopez",
                 surname2=None,
@@ -292,7 +292,7 @@ def test_register_user_maps_errors(error, status_code, detail):
         auth_controller.register_user(
             RegisterUserRequest(
                 username="u17",
-                password="secret",
+                password="secret-pass-123",
                 name="Ana",
                 surname1="Lopez",
                 surname2=None,
@@ -310,7 +310,7 @@ def test_register_admin_returns_session_response(monkeypatch):
     _stub_create_session(monkeypatch)
 
     response = auth_controller.register_admin(
-        RegisterAdminRequest(username="a23", password="secret", name="Admin"),
+        RegisterAdminRequest(username="a23", password="secret-pass-123", name="Admin"),
         command_bus=bus,
         db=object(),
     )
@@ -340,7 +340,7 @@ def test_register_admin_rolls_back_when_create_session_fails(monkeypatch):
 
     with pytest.raises(RuntimeError):
         auth_controller.register_admin(
-            RegisterAdminRequest(username="a23", password="secret", name="Admin"),
+            RegisterAdminRequest(username="a23", password="secret-pass-123", name="Admin"),
             command_bus=bus,
             db=db,
         )
@@ -358,7 +358,7 @@ def test_register_admin_rolls_back_when_create_session_fails(monkeypatch):
 def test_register_admin_maps_errors(error, status_code, detail):
     with pytest.raises(HTTPException) as exc:
         auth_controller.register_admin(
-            RegisterAdminRequest(username="a23", password="secret", name="Admin"),
+            RegisterAdminRequest(username="a23", password="secret-pass-123", name="Admin"),
             command_bus=_RaisingCommandBus(error),
             db=object(),
         )
@@ -387,3 +387,48 @@ def test_logout_invalidates_session_and_returns_ok(monkeypatch):
 
     assert calls == {"token": "tok-123"}
     assert response == {"status": "ok"}
+
+
+def test_admin_registration_secret_disabled_when_env_unset(monkeypatch):
+    monkeypatch.delenv("ADMIN_REGISTRATION_SECRET", raising=False)
+    with pytest.raises(HTTPException) as exc:
+        auth_controller.require_admin_registration_secret(x_admin_registration_secret="anything")
+    assert exc.value.status_code == 403
+    assert exc.value.detail == "Admin registration is disabled"
+
+
+def test_admin_registration_secret_rejects_wrong_value(monkeypatch):
+    monkeypatch.setenv("ADMIN_REGISTRATION_SECRET", "expected-secret")
+    with pytest.raises(HTTPException) as exc:
+        auth_controller.require_admin_registration_secret(x_admin_registration_secret="wrong")
+    assert exc.value.status_code == 403
+    assert exc.value.detail == "Invalid admin registration secret"
+
+
+def test_admin_registration_secret_rejects_missing_header(monkeypatch):
+    monkeypatch.setenv("ADMIN_REGISTRATION_SECRET", "expected-secret")
+    with pytest.raises(HTTPException) as exc:
+        auth_controller.require_admin_registration_secret(x_admin_registration_secret=None)
+    assert exc.value.status_code == 403
+
+
+def test_admin_registration_secret_accepts_matching_value(monkeypatch):
+    monkeypatch.setenv("ADMIN_REGISTRATION_SECRET", "expected-secret")
+    # Returns None (no exception) when the header matches.
+    assert (
+        auth_controller.require_admin_registration_secret(
+            x_admin_registration_secret="expected-secret"
+        )
+        is None
+    )
+
+
+@pytest.mark.parametrize("model", [RegisterUserRequest, RegisterAdminRequest])
+def test_registration_rejects_short_password(model):
+    from pydantic import ValidationError
+
+    fields = {"username": "u", "password": "short", "name": "N"}
+    if model is RegisterUserRequest:
+        fields |= {"surname1": "S", "nationality": "ES"}
+    with pytest.raises(ValidationError):
+        model(**fields)

--- a/docker/docker-compose.ci.yml
+++ b/docker/docker-compose.ci.yml
@@ -41,6 +41,8 @@ services:
       DB_PROVIDER: mysql+pymysql
       LINK_TOKEN_TTL_SECONDS: 3600
       SESSION_TTL_SECONDS: 3600
+      # Must match TEST_ADMIN_REGISTRATION_SECRET default in the integration helpers.
+      ADMIN_REGISTRATION_SECRET: test-admin-registration-secret
     ports:
       - "8000:8000"
     healthcheck:


### PR DESCRIPTION
fixes #119 + #120  
fix(auth): close open admin self-registration and enforce password policy
Fixes #119, Fixes #120

Summary
Two security fixes from the audit, both in the auth boundary:

#119 (Critical) — Open admin self-registration → privilege escalation. POST /api/v1/auth/admin/register had no authentication: any anonymous client could create a fully privileged admin account and receive an admin session.
#120 (High) — No password strength policy. Registration accepted 1-character passwords (Field(min_length=1)), enabling trivial credential guessing.
Changes
#119 — admin registration secret (fail-closed)

Added require_admin_registration_secret as an endpoint dependency on /auth/admin/register. It requires an X-Admin-Registration-Secret header matching the server-side ADMIN_REGISTRATION_SECRET env var, compared with secrets.compare_digest (constant-time).
Fail-closed: if ADMIN_REGISTRATION_SECRET is unset/empty, the endpoint returns 403 Admin registration is disabled — anonymous escalation is impossible by default.
Implemented as dependencies=[...] so the handler signature is unchanged.
#120 — password policy

Bumped password min length 1 → 12 on RegisterUserRequest and RegisterAdminRequest.
LoginRequest intentionally left at min_length=1 so accounts created before this policy can still authenticate (policy applies at registration only).
Why a secret, not require_admin
No admin is seeded anywhere (the admin_accounts table is empty on init), so this endpoint is the bootstrap path. Gating it behind an existing admin would lock everyone out of a fresh deployment. The shared secret closes the hole while keeping bootstrap possible. Per-admin invite tokens are the upgrade path if/when needed.

Tests
Added 4 guard tests (env unset → disabled; wrong/missing header → 403; matching header → pass) and a parametrized short-password rejection test.
Updated existing registration unit fixtures to 12-char passwords.
Updated the 4 integration helpers to send the secret header (TEST_ADMIN_REGISTRATION_SECRET, default test-admin-registration-secret) and 12-char passwords.
✅ 733 unit tests pass; ruff format + lint clean.
⚠️ Operator action required (breaking)
Add ADMIN_REGISTRATION_SECRET to each environment's config (now in .template.env). Until set, admin registration is disabled — including existing local backend/config/.env files, which won't have the new key.
Admin-registration callers must send the X-Admin-Registration-Secret header.
Integration runs need the server started with a matching ADMIN_REGISTRATION_SECRET. (Integration tests need a live DB+server and were not run in this change.)
Not included (follow-ups from the audit)
Rate limiting / lockout on auth endpoints (SEC-3 / IMP-10).
Secret rotation / per-admin invite tokens — the static shared secret is a known ceiling.
