### PR TITLE
Develop

### DIFF
--- a/backend/config/.template.env
+++ b/backend/config/.template.env
@@ -1,7 +1,12 @@
 APP_HOST=0.0.0.0
 APP_PORT=8000
 APP_RELOAD=true
+APP_ENV=development
 EXPOSE_INTERNAL_ERRORS=false
+RATE_LIMIT_ENABLED=true
+RATE_LIMIT_REQUESTS=300
+RATE_LIMIT_AUTH_REQUESTS=20
+RATE_LIMIT_WINDOW_SECONDS=60
 LINK_TOKEN_TTL_SECONDS=86400
 # Required to create admin accounts via POST /api/v1/auth/admin/register.
 # Leave unset/empty to DISABLE admin registration (fail closed). Requests must

--- a/backend/src/api/interface/controller/v1/auth_controller.py
+++ b/backend/src/api/interface/controller/v1/auth_controller.py
@@ -12,7 +12,10 @@ from api.interface.controller.v1.model.request.auth_request import (
     RegisterAdminRequest,
     RegisterUserRequest,
 )
-from api.interface.controller.v1.model.response.auth_response import LoginResponse
+from api.interface.controller.v1.model.response.auth_response import (
+    LoginResponse,
+    SessionResponse,
+)
 from api.middleware.exception_mapper import map_exceptions
 from auth.application.use_cases.login import (
     InvalidCredentialsError,
@@ -20,13 +23,17 @@ from auth.application.use_cases.login import (
     LoginPayload,
     LoginUserUseCase,
 )
-from auth.dependencies import get_current_session
+from auth.dependencies import (
+    clear_session_cookie,
+    get_current_session,
+    set_session_cookie,
+)
 from auth.session import create_session, invalidate_session
 from core.application.commands.registration_commands import (
     RegisterAdminCommand,
     RegisterUserCommand,
 )
-from fastapi import APIRouter, Depends, Header, HTTPException, status
+from fastapi import APIRouter, Depends, Header, HTTPException, Response, status
 from persistence.module import get_db
 from shared.application.bus.buses import CommandBus
 from sqlalchemy.orm import Session
@@ -65,6 +72,7 @@ def require_admin_registration_secret(
 @map_exceptions
 def login_user(
     payload: LoginRequest,
+    response: Response,
     use_case: LoginUserUseCase = Depends(get_login_user_use_case),
     db: Session = Depends(get_db),
 ):
@@ -75,6 +83,7 @@ def login_user(
         logger.warning("User login failed: invalid credentials")
         raise
     session = create_session(db, user_id=user.id, user_guid=user.guid, user_type="user")
+    set_session_cookie(response, session)
     logger.info("User login ok: %s", user.guid)
     return LoginResponse(
         token=session.token,
@@ -89,6 +98,7 @@ def login_user(
 @map_exceptions
 def login_admin(
     payload: LoginRequest,
+    response: Response,
     use_case: LoginAdminUseCase = Depends(get_login_admin_use_case),
     db: Session = Depends(get_db),
 ):
@@ -99,6 +109,7 @@ def login_admin(
         logger.warning("Admin login failed: invalid credentials")
         raise
     session = create_session(db, user_id=admin.id, user_guid=admin.guid, user_type="admin")
+    set_session_cookie(response, session)
     logger.info("Admin login ok: %s", admin.guid)
     return LoginResponse(
         token=session.token,
@@ -113,6 +124,7 @@ def login_admin(
 @map_exceptions
 def register_user(
     payload: RegisterUserRequest,
+    response: Response,
     command_bus: CommandBus = Depends(get_registration_command_bus),
     db: Session = Depends(get_db),
 ):
@@ -137,6 +149,7 @@ def register_user(
     except Exception:
         db.rollback()
         raise
+    set_session_cookie(response, session)
     logger.info("User register ok: %s", registered.account_guid)
     return LoginResponse(
         token=session.token,
@@ -155,6 +168,7 @@ def register_user(
 @map_exceptions
 def register_admin(
     payload: RegisterAdminRequest,
+    response: Response,
     command_bus: CommandBus = Depends(get_registration_command_bus),
     db: Session = Depends(get_db),
 ):
@@ -176,6 +190,7 @@ def register_admin(
     except Exception:
         db.rollback()
         raise
+    set_session_cookie(response, session)
     logger.info("Admin register ok: %s", registered.admin_guid)
     return LoginResponse(
         token=session.token,
@@ -186,7 +201,22 @@ def register_admin(
     )
 
 
+@router.get("/auth/session", response_model=SessionResponse)
+def read_session(session=Depends(get_current_session)):
+    """Restore session metadata from the cookie (used by the SPA on reload)."""
+    return SessionResponse(
+        expires_at=session.expires_at,
+        user_guid=session.user_guid,
+        user_type=session.user_type,
+    )
+
+
 @router.post("/auth/logout")
-def logout(session=Depends(get_current_session), db: Session = Depends(get_db)):
+def logout(
+    response: Response,
+    session=Depends(get_current_session),
+    db: Session = Depends(get_db),
+):
     invalidate_session(db, session.token)
+    clear_session_cookie(response)
     return {"status": "ok"}

--- a/backend/src/api/interface/controller/v1/model/response/auth_response.py
+++ b/backend/src/api/interface/controller/v1/model/response/auth_response.py
@@ -7,3 +7,11 @@ class LoginResponse(BaseModel):
     expires_at: int
     user_guid: str
     user_type: str
+
+
+class SessionResponse(BaseModel):
+    """Non-sensitive session metadata; the token itself lives only in the cookie."""
+
+    expires_at: int
+    user_guid: str
+    user_type: str

--- a/backend/src/api/interface/controller/v1/penas_controller.py
+++ b/backend/src/api/interface/controller/v1/penas_controller.py
@@ -43,6 +43,7 @@ from auth.dependencies import (
     get_current_session,
     require_admin,
     require_user,
+    set_session_cookie,
 )
 from auth.session import create_session
 from core.application.commands.pena_accountability_commands import (
@@ -78,7 +79,7 @@ from core.application.queries.pena_queries import (
     ListPenasForAdminQuery,
     ListPenasForUserQuery,
 )
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
 from persistence.module import get_db
 from shared.application.bus.buses import CommandBus, QueryBus
 from sqlalchemy.orm import Session
@@ -512,6 +513,7 @@ def inspect_claim_token(
 @map_exceptions
 def register_and_claim_player(
     payload: RegisterAndClaimRequest,
+    response: Response,
     command_bus: CommandBus = Depends(get_pena_link_command_bus),
     db: Session = Depends(get_db),
 ):
@@ -532,6 +534,7 @@ def register_and_claim_player(
     except Exception:
         db.rollback()
         raise
+    set_session_cookie(response, session)
     return LoginResponse(
         token=session.token,
         token_type="session",

--- a/backend/src/api/middleware/rate_limit.py
+++ b/backend/src/api/middleware/rate_limit.py
@@ -31,10 +31,16 @@ class RateLimitDecision:
 
 
 class SlidingWindowRateLimiter:
+    # Sweep idle keys every N checks so the table doesn't grow unbounded with
+    # one-shot/rotating client IPs (their buckets expire but the dict entry lingers).
+    _SWEEP_EVERY = 1024
+
     def __init__(self, clock: Callable[[], float] = time.monotonic):
         self._clock = clock
         self._hits: dict[str, deque[float]] = {}
+        self._windows: dict[str, int] = {}
         self._lock = Lock()
+        self._checks_since_sweep = 0
 
     def check(self, key: str, rule: RateLimitRule) -> RateLimitDecision:
         now = self._clock()
@@ -43,7 +49,14 @@ class SlidingWindowRateLimiter:
         cutoff = now - window_seconds
 
         with self._lock:
+            self._checks_since_sweep += 1
+            if self._checks_since_sweep >= self._SWEEP_EVERY:
+                # Runs before the current key is (re)inserted; any key it drops has a
+                # fully-expired bucket, so recreating it empty below loses nothing.
+                self._sweep(now)
+
             bucket = self._hits.setdefault(key, deque())
+            self._windows[key] = window_seconds
             while bucket and bucket[0] <= cutoff:
                 bucket.popleft()
 
@@ -61,6 +74,19 @@ class SlidingWindowRateLimiter:
                 remaining=max_requests - len(bucket),
                 retry_after_seconds=0,
             )
+
+    def _sweep(self, now: float) -> None:
+        self._checks_since_sweep = 0
+        stale: list[str] = []
+        for stored_key, bucket in self._hits.items():
+            cutoff = now - self._windows.get(stored_key, 0)
+            while bucket and bucket[0] <= cutoff:
+                bucket.popleft()
+            if not bucket:
+                stale.append(stored_key)
+        for stored_key in stale:
+            del self._hits[stored_key]
+            self._windows.pop(stored_key, None)
 
 
 class RateLimitMiddleware(BaseHTTPMiddleware):

--- a/backend/src/api/middleware/rate_limit.py
+++ b/backend/src/api/middleware/rate_limit.py
@@ -1,0 +1,125 @@
+import math
+import time
+from collections import deque
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from threading import Lock
+
+from fastapi import Request
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.responses import JSONResponse, Response
+
+
+@dataclass(frozen=True)
+class RateLimitRule:
+    max_requests: int
+    window_seconds: int
+
+
+@dataclass(frozen=True)
+class RateLimitConfig:
+    enabled: bool
+    default_rule: RateLimitRule
+    auth_rule: RateLimitRule
+
+
+@dataclass(frozen=True)
+class RateLimitDecision:
+    allowed: bool
+    remaining: int
+    retry_after_seconds: int
+
+
+class SlidingWindowRateLimiter:
+    def __init__(self, clock: Callable[[], float] = time.monotonic):
+        self._clock = clock
+        self._hits: dict[str, deque[float]] = {}
+        self._lock = Lock()
+
+    def check(self, key: str, rule: RateLimitRule) -> RateLimitDecision:
+        now = self._clock()
+        window_seconds = max(1, rule.window_seconds)
+        max_requests = max(1, rule.max_requests)
+        cutoff = now - window_seconds
+
+        with self._lock:
+            bucket = self._hits.setdefault(key, deque())
+            while bucket and bucket[0] <= cutoff:
+                bucket.popleft()
+
+            if len(bucket) >= max_requests:
+                retry_after = max(1, math.ceil(bucket[0] + window_seconds - now))
+                return RateLimitDecision(
+                    allowed=False,
+                    remaining=0,
+                    retry_after_seconds=retry_after,
+                )
+
+            bucket.append(now)
+            return RateLimitDecision(
+                allowed=True,
+                remaining=max_requests - len(bucket),
+                retry_after_seconds=0,
+            )
+
+
+class RateLimitMiddleware(BaseHTTPMiddleware):
+    def __init__(
+        self,
+        app,
+        config: RateLimitConfig,
+        limiter: SlidingWindowRateLimiter | None = None,
+    ):
+        super().__init__(app)
+        self._config = config
+        self._limiter = limiter or SlidingWindowRateLimiter()
+
+    async def dispatch(
+        self,
+        request: Request,
+        call_next: Callable[[Request], Awaitable[Response]],
+    ) -> Response:
+        if not self._config.enabled or request.method == "OPTIONS":
+            return await call_next(request)
+
+        path = request.url.path
+        if self._is_exempt_path(path):
+            return await call_next(request)
+
+        rule_name, rule = self._select_rule(path)
+        client_host = request.client.host if request.client else "unknown"
+        decision = self._limiter.check(f"{client_host}:{rule_name}", rule)
+        if not decision.allowed:
+            return JSONResponse(
+                status_code=429,
+                content={"detail": "Too many requests"},
+                headers={
+                    "Retry-After": str(decision.retry_after_seconds),
+                    "X-RateLimit-Limit": str(rule.max_requests),
+                    "X-RateLimit-Remaining": "0",
+                },
+            )
+
+        response = await call_next(request)
+        response.headers["X-RateLimit-Limit"] = str(rule.max_requests)
+        response.headers["X-RateLimit-Remaining"] = str(decision.remaining)
+        return response
+
+    @staticmethod
+    def _is_exempt_path(path: str) -> bool:
+        return path in {
+            "/",
+            "/api",
+            "/api/",
+            "/docs",
+            "/api/docs",
+            "/redoc",
+            "/api/redoc",
+            "/openapi.json",
+            "/api/openapi.json",
+        }
+
+    def _select_rule(self, path: str) -> tuple[str, RateLimitRule]:
+        if "/auth/" in path:
+            return "auth", self._config.auth_rule
+        return "default", self._config.default_rule

--- a/backend/src/auth/dependencies.py
+++ b/backend/src/auth/dependencies.py
@@ -1,3 +1,5 @@
+import os
+
 from auth.application.use_cases.authorize_access import (
     AuthorizePenaAccessUseCase,
     AuthorizePlayerAccessUseCase,
@@ -7,27 +9,68 @@ from auth.infrastructure.repositories.sqlalchemy_access_repository import (
     SqlAlchemyAccessRepository,
 )
 from auth.session import SessionData, get_session
-from fastapi import Depends, Header, HTTPException, status
+from fastapi import Cookie, Depends, Header, HTTPException, Response, status
 from persistence.module import get_db
 from sqlalchemy.orm import Session
 
+SESSION_COOKIE_NAME = "session"
 
-def _extract_token(authorization: str | None, x_session_token: str | None) -> str | None:
+
+def _cookie_secure() -> bool:
+    """Set the Secure flag outside dev/test (HTTPS-only in production)."""
+    env = os.getenv("APP_ENV", "production").strip().lower()
+    return env not in {"dev", "development", "local", "test"}
+
+
+def set_session_cookie(response: Response, session: SessionData) -> None:
+    """Store the session token in an HttpOnly cookie (kept out of JS / localStorage)."""
+    import time
+
+    max_age = max(0, session.expires_at - int(time.time()))
+    response.set_cookie(
+        key=SESSION_COOKIE_NAME,
+        value=session.token,
+        max_age=max_age,
+        httponly=True,
+        secure=_cookie_secure(),
+        samesite="strict",
+        path="/",
+    )
+
+
+def clear_session_cookie(response: Response) -> None:
+    response.delete_cookie(
+        key=SESSION_COOKIE_NAME,
+        path="/",
+        httponly=True,
+        secure=_cookie_secure(),
+        samesite="strict",
+    )
+
+
+def _extract_token(
+    authorization: str | None,
+    x_session_token: str | None,
+    session_cookie: str | None = None,
+) -> str | None:
     if authorization:
         parts = authorization.split()
         if len(parts) == 2 and parts[0].lower() == "bearer":
             return parts[1]
     if x_session_token:
         return x_session_token
+    if session_cookie:
+        return session_cookie
     return None
 
 
 def get_current_session(
     authorization: str | None = Header(default=None),
     x_session_token: str | None = Header(default=None, alias="X-Session-Token"),
+    session_cookie: str | None = Cookie(default=None, alias=SESSION_COOKIE_NAME),
     db: Session = Depends(get_db),
 ) -> SessionData:
-    token = _extract_token(authorization, x_session_token)
+    token = _extract_token(authorization, x_session_token, session_cookie)
     if not token:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -211,8 +211,13 @@ app = FastAPI(
     redoc_url="/redoc",
 )
 
-# Middleware
+# Middleware. Starlette runs the LAST-added middleware outermost, so CORS must be
+# added last: otherwise short-circuit responses (e.g. a 429 from the rate limiter,
+# a 400 from TrustedHost) skip CORS and reach browsers without Access-Control
+# headers, surfacing as an opaque CORS error instead of the real status.
 app.add_middleware(GZipMiddleware, minimum_size=1000)
+app.add_middleware(RateLimitMiddleware, config=_resolve_rate_limit_config())
+app.add_middleware(TrustedHostMiddleware, allowed_hosts=_resolve_allowed_hosts())
 cors_origins = _resolve_cors_origins()
 app.add_middleware(
     CORSMiddleware,
@@ -221,8 +226,6 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
-app.add_middleware(TrustedHostMiddleware, allowed_hosts=_resolve_allowed_hosts())
-app.add_middleware(RateLimitMiddleware, config=_resolve_rate_limit_config())
 
 
 # Global exception handler

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -13,6 +13,7 @@ if not logging.getLogger().handlers:
         format="%(asctime)s %(levelname)s %(name)s %(message)s",
     )
 
+from api.middleware.rate_limit import RateLimitConfig, RateLimitMiddleware, RateLimitRule
 from api.module import api_router
 from app.config import config as app_config
 from app.module import engine
@@ -29,7 +30,23 @@ logger = logging.getLogger(__name__)
 
 
 def _app_env() -> str:
-    return os.getenv("APP_ENV", "development").strip().lower()
+    return os.getenv("APP_ENV", "production").strip().lower()
+
+
+def _env_bool(name: str, *, default: bool) -> bool:
+    raw_value = os.getenv(name)
+    if raw_value is None:
+        return default
+    return raw_value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _env_int(name: str, *, default: int, minimum: int = 1) -> int:
+    raw_value = os.getenv(name)
+    try:
+        value = int(raw_value) if raw_value is not None else default
+    except ValueError:
+        value = default
+    return max(minimum, value)
 
 
 def _resolve_allowed_hosts() -> list[str]:
@@ -64,11 +81,7 @@ def _resolve_cors_origins() -> list[str]:
 
 
 def _resolve_cors_allow_credentials(origins: list[str]) -> bool:
-    raw_value = os.getenv("CORS_ALLOW_CREDENTIALS")
-    if raw_value is not None:
-        allow_credentials = raw_value.strip().lower() in {"1", "true", "yes", "on"}
-    else:
-        allow_credentials = False
+    allow_credentials = _env_bool("CORS_ALLOW_CREDENTIALS", default=False)
 
     # Browsers reject '*' when credentials are enabled, and it is insecure.
     if allow_credentials and "*" in origins:
@@ -78,15 +91,25 @@ def _resolve_cors_allow_credentials(origins: list[str]) -> bool:
 
 
 def _include_debug_error_detail() -> bool:
-    raw_value = os.getenv("EXPOSE_INTERNAL_ERRORS")
-    if raw_value is None:
-        return False
-    expose_internal_errors = raw_value.strip().lower() in {"1", "true", "yes", "on"}
-    if not expose_internal_errors:
+    if not _env_bool("EXPOSE_INTERNAL_ERRORS", default=False):
         return False
 
     app_env = _app_env()
     return app_env in {"dev", "development", "local", "test"}
+
+
+def _resolve_rate_limit_config() -> RateLimitConfig:
+    return RateLimitConfig(
+        enabled=_env_bool("RATE_LIMIT_ENABLED", default=True),
+        default_rule=RateLimitRule(
+            max_requests=_env_int("RATE_LIMIT_REQUESTS", default=300),
+            window_seconds=_env_int("RATE_LIMIT_WINDOW_SECONDS", default=60),
+        ),
+        auth_rule=RateLimitRule(
+            max_requests=_env_int("RATE_LIMIT_AUTH_REQUESTS", default=20),
+            window_seconds=_env_int("RATE_LIMIT_WINDOW_SECONDS", default=60),
+        ),
+    )
 
 
 def _db_startup_retries() -> tuple[int, float]:
@@ -199,6 +222,7 @@ app.add_middleware(
     allow_headers=["*"],
 )
 app.add_middleware(TrustedHostMiddleware, allowed_hosts=_resolve_allowed_hosts())
+app.add_middleware(RateLimitMiddleware, config=_resolve_rate_limit_config())
 
 
 # Global exception handler

--- a/backend/tests/test_auth_controller.py
+++ b/backend/tests/test_auth_controller.py
@@ -21,7 +21,7 @@ from core.domain.errors import (
     UserInvalidNationalityError,
     UserUsernameExistsError,
 )
-from fastapi import HTTPException
+from fastapi import HTTPException, Response
 
 
 def _session(*, user_type: str, user_guid: str) -> SessionData:
@@ -118,12 +118,15 @@ def test_login_user_returns_session_response(monkeypatch):
         ),
     )
 
+    http_response = Response()
     response = auth_controller.login_user(
         LoginRequest(username="alice", password="secret"),
+        http_response,
         use_case=use_case,
         db=object(),
     )
 
+    assert "session=session-token" in http_response.headers.get("set-cookie", "")
     assert use_case.last_payload.username == "alice"
     assert response.token == "session-token"
     assert response.user_guid == "user-guid-7"
@@ -138,6 +141,7 @@ def test_login_user_maps_invalid_credentials():
     with pytest.raises(HTTPException) as exc:
         auth_controller.login_user(
             LoginRequest(username="alice", password="wrong"),
+            Response(),
             use_case=_UseCase(),
             db=object(),
         )
@@ -164,12 +168,15 @@ def test_login_admin_returns_session_response(monkeypatch):
         ),
     )
 
+    http_response = Response()
     response = auth_controller.login_admin(
         LoginRequest(username="root", password="secret"),
+        http_response,
         use_case=_UseCase(),
         db=object(),
     )
 
+    assert "session=session-token" in http_response.headers.get("set-cookie", "")
     assert response.token_type == "session"
     assert response.user_guid == "admin-guid-9"
     assert response.user_type == "admin"
@@ -183,6 +190,7 @@ def test_login_admin_maps_invalid_credentials():
     with pytest.raises(HTTPException) as exc:
         auth_controller.login_admin(
             LoginRequest(username="root", password="wrong"),
+            Response(),
             use_case=_UseCase(),
             db=object(),
         )
@@ -224,6 +232,7 @@ def test_register_user_returns_session_response(monkeypatch):
     )
     _stub_create_session(monkeypatch)
 
+    http_response = Response()
     response = auth_controller.register_user(
         RegisterUserRequest(
             username="u17",
@@ -233,10 +242,12 @@ def test_register_user_returns_session_response(monkeypatch):
             surname2=None,
             nationality="ES",
         ),
+        http_response,
         command_bus=bus,
         db=object(),
     )
 
+    assert "session=session-token" in http_response.headers.get("set-cookie", "")
     assert isinstance(bus.last_command, RegisterUserCommand)
     assert bus.last_command.username == "u17"
     assert response.user_guid == "user-guid-17"
@@ -272,6 +283,7 @@ def test_register_user_rolls_back_when_create_session_fails(monkeypatch):
                 surname2=None,
                 nationality="ES",
             ),
+            Response(),
             command_bus=bus,
             db=db,
         )
@@ -298,6 +310,7 @@ def test_register_user_maps_errors(error, status_code, detail):
                 surname2=None,
                 nationality="ES",
             ),
+            Response(),
             command_bus=_RaisingCommandBus(error),
             db=object(),
         )
@@ -309,12 +322,15 @@ def test_register_admin_returns_session_response(monkeypatch):
     bus = _RegistrationCommandBus(RegisteredAdmin(admin_id=23, admin_guid="admin-guid-23"))
     _stub_create_session(monkeypatch)
 
+    http_response = Response()
     response = auth_controller.register_admin(
         RegisterAdminRequest(username="a23", password="secret-pass-123", name="Admin"),
+        http_response,
         command_bus=bus,
         db=object(),
     )
 
+    assert "session=session-token" in http_response.headers.get("set-cookie", "")
     assert isinstance(bus.last_command, RegisterAdminCommand)
     assert bus.last_command.username == "a23"
     assert response.user_guid == "admin-guid-23"
@@ -341,6 +357,7 @@ def test_register_admin_rolls_back_when_create_session_fails(monkeypatch):
     with pytest.raises(RuntimeError):
         auth_controller.register_admin(
             RegisterAdminRequest(username="a23", password="secret-pass-123", name="Admin"),
+            Response(),
             command_bus=bus,
             db=db,
         )
@@ -359,6 +376,7 @@ def test_register_admin_maps_errors(error, status_code, detail):
     with pytest.raises(HTTPException) as exc:
         auth_controller.register_admin(
             RegisterAdminRequest(username="a23", password="secret-pass-123", name="Admin"),
+            Response(),
             command_bus=_RaisingCommandBus(error),
             db=object(),
         )
@@ -374,7 +392,9 @@ def test_logout_invalidates_session_and_returns_ok(monkeypatch):
 
     monkeypatch.setattr(auth_controller, "invalidate_session", _fake_invalidate)
 
+    http_response = Response()
     response = auth_controller.logout(
+        http_response,
         session=SessionData(
             token="tok-123",
             user_id=1,
@@ -387,6 +407,7 @@ def test_logout_invalidates_session_and_returns_ok(monkeypatch):
 
     assert calls == {"token": "tok-123"}
     assert response == {"status": "ok"}
+    assert "session=" in http_response.headers.get("set-cookie", "")
 
 
 def test_admin_registration_secret_disabled_when_env_unset(monkeypatch):
@@ -432,3 +453,18 @@ def test_registration_rejects_short_password(model):
         fields |= {"surname1": "S", "nationality": "ES"}
     with pytest.raises(ValidationError):
         model(**fields)
+
+
+def test_read_session_returns_metadata_without_token():
+    session = SessionData(
+        token="tok-secret",
+        user_id=3,
+        user_guid="guid-3",
+        user_type="admin",
+        expires_at=4242,
+    )
+    result = auth_controller.read_session(session=session)
+    assert result.user_guid == "guid-3"
+    assert result.user_type == "admin"
+    assert result.expires_at == 4242
+    assert not hasattr(result, "token")

--- a/backend/tests/test_auth_controller_logging.py
+++ b/backend/tests/test_auth_controller_logging.py
@@ -2,7 +2,7 @@ import logging
 import os
 
 import pytest
-from fastapi import HTTPException
+from fastapi import HTTPException, Response
 
 # Required so importing auth controller does not fail during test collection.
 os.environ.setdefault("DB_HOST", "localhost")
@@ -34,7 +34,7 @@ def test_user_login_failure_logs_do_not_expose_username_or_password(caplog):
 
     with caplog.at_level(logging.WARNING):
         with pytest.raises(HTTPException) as exc:
-            auth_controller.login_user(payload, use_case=use_case, db=object())
+            auth_controller.login_user(payload, Response(), use_case=use_case, db=object())
 
     assert exc.value.status_code == 401
     assert "invalid credentials" in caplog.text.lower()
@@ -48,7 +48,7 @@ def test_admin_login_failure_logs_do_not_expose_username_or_password(caplog):
 
     with caplog.at_level(logging.WARNING):
         with pytest.raises(HTTPException) as exc:
-            auth_controller.login_admin(payload, use_case=use_case, db=object())
+            auth_controller.login_admin(payload, Response(), use_case=use_case, db=object())
 
     assert exc.value.status_code == 401
     assert "invalid credentials" in caplog.text.lower()

--- a/backend/tests/test_auth_dependencies.py
+++ b/backend/tests/test_auth_dependencies.py
@@ -36,7 +36,9 @@ def test_extract_token_returns_none_when_no_token_present():
 
 def test_get_current_session_raises_401_when_missing_token():
     with pytest.raises(HTTPException) as exc:
-        dependencies.get_current_session(authorization=None, x_session_token=None, db=object())
+        dependencies.get_current_session(
+            authorization=None, x_session_token=None, session_cookie=None, db=object()
+        )
     assert exc.value.status_code == 401
     assert exc.value.detail == "Missing session token"
 
@@ -220,3 +222,64 @@ def test_authorize_player_access_maps_use_case_errors_to_http(monkeypatch, error
         )
     assert exc.value.status_code == 403
     assert exc.value.detail == detail
+
+
+def test_extract_token_falls_back_to_session_cookie():
+    # Header sources take precedence; cookie is the last resort.
+    assert dependencies._extract_token(None, None, "cookie-token") == "cookie-token"
+    assert dependencies._extract_token("Bearer hdr", None, "cookie-token") == "hdr"
+    assert dependencies._extract_token(None, "xtok", "cookie-token") == "xtok"
+    assert dependencies._extract_token(None, None, None) is None
+
+
+def test_get_current_session_reads_token_from_cookie(monkeypatch):
+    captured = {}
+
+    def _fake_get_session(_db, token):
+        captured["token"] = token
+        return _session(user_type="user")
+
+    monkeypatch.setattr(dependencies, "get_session", _fake_get_session)
+
+    session = dependencies.get_current_session(
+        authorization=None,
+        x_session_token=None,
+        session_cookie="cookie-token",
+        db=object(),
+    )
+    assert captured["token"] == "cookie-token"
+    assert session.user_type == "user"
+
+
+def test_set_session_cookie_is_httponly_and_samesite_strict(monkeypatch):
+    from fastapi import Response
+
+    monkeypatch.setenv("APP_ENV", "production")
+    response = Response()
+    dependencies.set_session_cookie(response, _session(user_type="admin"))
+
+    header = response.headers.get("set-cookie", "")
+    assert "session=token-1" in header
+    assert "HttpOnly" in header
+    assert "SameSite=strict" in header.replace("Strict", "strict")
+    assert "Secure" in header
+
+
+def test_set_session_cookie_omits_secure_in_dev(monkeypatch):
+    from fastapi import Response
+
+    monkeypatch.setenv("APP_ENV", "development")
+    response = Response()
+    dependencies.set_session_cookie(response, _session(user_type="user"))
+
+    assert "Secure" not in response.headers.get("set-cookie", "")
+
+
+def test_clear_session_cookie_expires_the_cookie():
+    from fastapi import Response
+
+    response = Response()
+    dependencies.clear_session_cookie(response)
+    header = response.headers.get("set-cookie", "")
+    assert "session=" in header
+    assert "Max-Age=0" in header or "expires=Thu, 01 Jan 1970" in header

--- a/backend/tests/test_main_runtime_config.py
+++ b/backend/tests/test_main_runtime_config.py
@@ -11,9 +11,11 @@ os.environ.setdefault("DB_USER", "footballuser")
 os.environ.setdefault("DB_PASSWORD", "footballpass")
 
 from main import (
+    _app_env,
     _include_debug_error_detail,
     _resolve_cors_allow_credentials,
     _resolve_cors_origins,
+    _resolve_rate_limit_config,
     global_exception_handler,
 )
 
@@ -63,6 +65,11 @@ def test_resolve_cors_allow_credentials_disables_with_wildcard(monkeypatch):
     assert allow_credentials is False
 
 
+def test_app_env_defaults_to_production(monkeypatch):
+    monkeypatch.delenv("APP_ENV", raising=False)
+    assert _app_env() == "production"
+
+
 def test_include_debug_error_detail_depends_on_env(monkeypatch):
     monkeypatch.delenv("EXPOSE_INTERNAL_ERRORS", raising=False)
     monkeypatch.setenv("APP_ENV", "test")
@@ -73,6 +80,34 @@ def test_include_debug_error_detail_depends_on_env(monkeypatch):
 
     monkeypatch.setenv("APP_ENV", "production")
     assert _include_debug_error_detail() is False
+
+
+def test_resolve_rate_limit_config_uses_safe_defaults(monkeypatch):
+    monkeypatch.delenv("RATE_LIMIT_ENABLED", raising=False)
+    monkeypatch.delenv("RATE_LIMIT_REQUESTS", raising=False)
+    monkeypatch.delenv("RATE_LIMIT_AUTH_REQUESTS", raising=False)
+    monkeypatch.delenv("RATE_LIMIT_WINDOW_SECONDS", raising=False)
+
+    config = _resolve_rate_limit_config()
+
+    assert config.enabled is True
+    assert config.default_rule.max_requests == 300
+    assert config.auth_rule.max_requests == 20
+    assert config.default_rule.window_seconds == 60
+
+
+def test_resolve_rate_limit_config_parses_and_clamps_values(monkeypatch):
+    monkeypatch.setenv("RATE_LIMIT_ENABLED", "false")
+    monkeypatch.setenv("RATE_LIMIT_REQUESTS", "0")
+    monkeypatch.setenv("RATE_LIMIT_AUTH_REQUESTS", "invalid")
+    monkeypatch.setenv("RATE_LIMIT_WINDOW_SECONDS", "-5")
+
+    config = _resolve_rate_limit_config()
+
+    assert config.enabled is False
+    assert config.default_rule.max_requests == 1
+    assert config.auth_rule.max_requests == 20
+    assert config.default_rule.window_seconds == 1
 
 
 def test_global_exception_handler_returns_detailed_error_in_test(monkeypatch):

--- a/backend/tests/test_penas_controller.py
+++ b/backend/tests/test_penas_controller.py
@@ -74,7 +74,7 @@ from core.domain.errors import (
     UserAlreadyLinkedError,
     UserProfileNotFoundError,
 )
-from fastapi import HTTPException
+from fastapi import HTTPException, Response
 
 
 def _session(*, user_type: str, user_id: int = 7) -> SessionData:
@@ -589,12 +589,15 @@ def test_register_and_claim_player_success(monkeypatch):
 
     monkeypatch.setattr(penas_controller, "create_session", _fake_create_session)
 
+    http_response = Response()
     response = penas_controller.register_and_claim_player(
         RegisterAndClaimRequest(token="tok-claim", username="ana", password="secret"),
+        http_response,
         command_bus=bus,
         db=object(),
     )
 
+    assert "session=session-tok" in http_response.headers.get("set-cookie", "")
     assert response.token == "session-tok"
     assert response.user_guid == "acc-7"
     assert response.expires_at == 4242
@@ -616,6 +619,7 @@ def test_register_and_claim_player_maps_domain_errors(error, status_code, detail
     with pytest.raises(HTTPException) as exc:
         penas_controller.register_and_claim_player(
             RegisterAndClaimRequest(token="tok-claim", username="ana", password="secret"),
+            Response(),
             command_bus=_RaisingCommandBus(error),
             db=object(),
         )

--- a/backend/tests/test_rate_limit_middleware.py
+++ b/backend/tests/test_rate_limit_middleware.py
@@ -35,6 +35,24 @@ def test_sliding_window_rate_limiter_is_scoped_by_key():
     assert limiter.check("127.0.0.1:auth", rule).allowed is False
 
 
+def test_sweep_evicts_idle_keys_without_dropping_active_ones():
+    current_time = 100.0
+    limiter = SlidingWindowRateLimiter(clock=lambda: current_time)
+    limiter._SWEEP_EVERY = 1  # sweep on every check for the test
+    rule = RateLimitRule(max_requests=5, window_seconds=10)
+
+    limiter.check("idle:auth", rule)
+    assert "idle:auth" in limiter._hits
+
+    # Advance past the window so idle's bucket is fully expired, then touch another
+    # key to trigger a sweep. The idle key is evicted; the active one survives.
+    current_time = 200.0
+    limiter.check("active:auth", rule)
+
+    assert "idle:auth" not in limiter._hits
+    assert "active:auth" in limiter._hits
+
+
 def test_rate_limit_middleware_rejects_when_limiter_denies():
     from api.middleware.rate_limit import RateLimitConfig, RateLimitMiddleware
     from starlette.requests import Request

--- a/backend/tests/test_rate_limit_middleware.py
+++ b/backend/tests/test_rate_limit_middleware.py
@@ -1,0 +1,82 @@
+import asyncio
+
+from api.middleware.rate_limit import RateLimitRule, SlidingWindowRateLimiter
+
+
+def test_sliding_window_rate_limiter_blocks_until_window_expires():
+    current_time = 100.0
+    limiter = SlidingWindowRateLimiter(clock=lambda: current_time)
+    rule = RateLimitRule(max_requests=2, window_seconds=10)
+
+    first = limiter.check("127.0.0.1:auth", rule)
+    second = limiter.check("127.0.0.1:auth", rule)
+    third = limiter.check("127.0.0.1:auth", rule)
+
+    assert first.allowed is True
+    assert first.remaining == 1
+    assert second.allowed is True
+    assert second.remaining == 0
+    assert third.allowed is False
+    assert third.retry_after_seconds == 10
+
+    current_time = 111.0
+    after_window = limiter.check("127.0.0.1:auth", rule)
+
+    assert after_window.allowed is True
+    assert after_window.remaining == 1
+
+
+def test_sliding_window_rate_limiter_is_scoped_by_key():
+    limiter = SlidingWindowRateLimiter(clock=lambda: 100.0)
+    rule = RateLimitRule(max_requests=1, window_seconds=10)
+
+    assert limiter.check("127.0.0.1:auth", rule).allowed is True
+    assert limiter.check("127.0.0.2:auth", rule).allowed is True
+    assert limiter.check("127.0.0.1:auth", rule).allowed is False
+
+
+def test_rate_limit_middleware_rejects_when_limiter_denies():
+    from api.middleware.rate_limit import RateLimitConfig, RateLimitMiddleware
+    from starlette.requests import Request
+    from starlette.responses import JSONResponse
+
+    class _Limiter:
+        def check(self, key, rule):
+            from api.middleware.rate_limit import RateLimitDecision
+
+            assert key == "127.0.0.1:auth"
+            assert rule.max_requests == 1
+            return RateLimitDecision(allowed=False, remaining=0, retry_after_seconds=7)
+
+    async def _call_next(_request):
+        return JSONResponse({"ok": True})
+
+    request = Request(
+        {
+            "type": "http",
+            "http_version": "1.1",
+            "method": "POST",
+            "scheme": "http",
+            "path": "/v1/auth/login",
+            "raw_path": b"/v1/auth/login",
+            "query_string": b"",
+            "headers": [],
+            "client": ("127.0.0.1", 12345),
+            "server": ("testserver", 80),
+        }
+    )
+    middleware = RateLimitMiddleware(
+        app=object(),
+        config=RateLimitConfig(
+            enabled=True,
+            default_rule=RateLimitRule(max_requests=10, window_seconds=60),
+            auth_rule=RateLimitRule(max_requests=1, window_seconds=60),
+        ),
+        limiter=_Limiter(),
+    )
+
+    response = asyncio.run(middleware.dispatch(request, _call_next))
+
+    assert response.status_code == 429
+    assert response.headers["Retry-After"] == "7"
+    assert response.headers["X-RateLimit-Remaining"] == "0"

--- a/deploy/helm/footballhub/examples/values-prod.yaml
+++ b/deploy/helm/footballhub/examples/values-prod.yaml
@@ -14,6 +14,11 @@ app:
   env: production
   allowedHosts: "app.example.com" # <-- your domain
   corsAllowedOrigins: "https://app.example.com" # <-- your domain, https
+  rateLimit:
+    enabled: true
+    requests: 300
+    authRequests: 20
+    windowSeconds: 60
   strictMigrationCheck: true
 
 # In-cluster MySQL is fine for a small single-node setup. For real production

--- a/deploy/helm/footballhub/templates/config.yaml
+++ b/deploy/helm/footballhub/templates/config.yaml
@@ -11,6 +11,10 @@ data:
   APP_RELOAD: "false"
   ALLOWED_HOSTS: {{ .Values.app.allowedHosts | quote }}
   CORS_ALLOWED_ORIGINS: {{ .Values.app.corsAllowedOrigins | quote }}
+  RATE_LIMIT_ENABLED: {{ .Values.app.rateLimit.enabled | quote }}
+  RATE_LIMIT_REQUESTS: {{ .Values.app.rateLimit.requests | quote }}
+  RATE_LIMIT_AUTH_REQUESTS: {{ .Values.app.rateLimit.authRequests | quote }}
+  RATE_LIMIT_WINDOW_SECONDS: {{ .Values.app.rateLimit.windowSeconds | quote }}
   LINK_TOKEN_TTL_SECONDS: {{ .Values.app.linkTokenTtlSeconds | quote }}
   SESSION_TTL_SECONDS: {{ .Values.app.sessionTtlSeconds | quote }}
   STRICT_MIGRATION_CHECK: {{ .Values.app.strictMigrationCheck | quote }}

--- a/deploy/helm/footballhub/values.yaml
+++ b/deploy/helm/footballhub/values.yaml
@@ -34,6 +34,11 @@ app:
   env: production
   allowedHosts: "" # comma-separated; e.g. "api.example.com"
   corsAllowedOrigins: "" # e.g. "https://app.example.com"
+  rateLimit:
+    enabled: true
+    requests: 300
+    authRequests: 20
+    windowSeconds: 60
   linkTokenTtlSeconds: 86400
   sessionTtlSeconds: 3600
   # Refuse to start the API if the schema has pending migrations (fail fast in

--- a/docker/docker-compose.ci.yml
+++ b/docker/docker-compose.ci.yml
@@ -43,6 +43,10 @@ services:
       SESSION_TTL_SECONDS: 3600
       # Must match TEST_ADMIN_REGISTRATION_SECRET default in the integration helpers.
       ADMIN_REGISTRATION_SECRET: test-admin-registration-secret
+      # The integration suite registers many accounts from a single IP, which would
+      # trip the per-IP auth rate limit. The limiter has its own unit tests; disable
+      # it here so the flow tests aren't throttled.
+      RATE_LIMIT_ENABLED: "false"
     ports:
       - "8000:8000"
     healthcheck:

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -133,6 +133,8 @@ Most relevant variables:
 
 - `APP_HOST`, `APP_PORT`, `APP_RELOAD`, `APP_ENV`
 - `EXPOSE_INTERNAL_ERRORS` (default `false`; enables detailed 500 responses only for local/dev/test)
+- `RATE_LIMIT_ENABLED`, `RATE_LIMIT_REQUESTS`, `RATE_LIMIT_AUTH_REQUESTS`,
+  `RATE_LIMIT_WINDOW_SECONDS`
 - `DB_HOST`, `DB_PORT`, `DB_NAME`, `DB_USER`, `DB_PASSWORD`, `DB_PROVIDER`
 - `LINK_TOKEN_TTL_SECONDS`, `SESSION_TTL_SECONDS`
 - `SQL_ECHO`

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -87,8 +87,9 @@ The frontend is a role-based application, not only an auth playground.
     - `useMatchDetailDialog`
 - API services:
   - `authService`, `adminService`, `userService`, `httpClient`.
-- Client session persistence:
-  - `sessionStore` (session payload + token in localStorage).
+- Client session handling:
+  - `sessionStore` keeps the current session token in memory only and clears legacy
+    localStorage token keys on startup/logout.
 - Analytics helpers:
   - `matchInsights.js` (comparison helpers and view-level transformations).
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -12,5 +12,11 @@ export default function App() {
     }
   }
 
+  // Hold the first paint until the cookie-based session check settles, so a
+  // reload doesn't bounce an authenticated user through the logged-out routes.
+  if (auth.status === 'restoring') {
+    return null
+  }
+
   return <AppRouter auth={auth} onLogout={handleLogout} />
 }

--- a/frontend/src/hooks/useAuth.js
+++ b/frontend/src/hooks/useAuth.js
@@ -17,13 +17,6 @@ export function useAuth() {
     const session = sessionStore.getSession()
     if (session?.token) {
       setState({ status: 'authenticated', token: session.token, error: null, session })
-      return
-    }
-    const token = sessionStore.getToken()
-    if (token) {
-      // Legacy token-only sessions (without metadata) are invalid for role-based UI.
-      sessionStore.clear()
-      setState(initialState)
     }
   }, [])
 

--- a/frontend/src/hooks/useAuth.js
+++ b/frontend/src/hooks/useAuth.js
@@ -1,27 +1,42 @@
 import { useEffect, useState } from 'react'
 import { authController } from '../services/authController.js'
-import { sessionStore } from '../services/sessionStore.js'
 
-const initialState = {
+// 'restoring' while we check the cookie on load, so the router can hold off
+// instead of flashing the logged-out UI for an authenticated user on reload.
+const restoringState = {
+  status: 'restoring',
+  error: null,
+  session: null,
+}
+
+const loggedOutState = {
   status: 'idle',
-  token: null,
   error: null,
   session: null,
 }
 
 export function useAuth() {
-  const [state, setState] = useState(initialState)
+  const [state, setState] = useState(restoringState)
 
   useEffect(() => {
-    sessionStore.init()
-    const session = sessionStore.getSession()
-    if (session?.token) {
-      setState({ status: 'authenticated', token: session.token, error: null, session })
+    let active = true
+    authController.restore().then((session) => {
+      if (!active) {
+        return
+      }
+      if (session?.user_type) {
+        setState({ status: 'authenticated', error: null, session })
+      } else {
+        setState(loggedOutState)
+      }
+    })
+    return () => {
+      active = false
     }
   }, [])
 
   const handleSuccess = (session) => {
-    setState({ status: 'authenticated', token: session.token, error: null, session })
+    setState({ status: 'authenticated', error: null, session })
   }
 
   const handleError = (error) => {
@@ -93,7 +108,7 @@ export function useAuth() {
     setState((prev) => ({ ...prev, status: 'loading', error: null }))
     try {
       await authController.logout()
-      setState(initialState)
+      setState(loggedOutState)
     } catch (error) {
       handleError(error)
       throw error

--- a/frontend/src/pages/ClaimPlayerPage.jsx
+++ b/frontend/src/pages/ClaimPlayerPage.jsx
@@ -45,7 +45,7 @@ export default function ClaimPlayerPage({ auth }) {
 
   // An already-signed-in player links the guest profile to their existing
   // account (merge) instead of registering a new one.
-  const isLoggedInUser = Boolean(auth?.token) && auth?.session?.user_type === 'user'
+  const isLoggedInUser = auth?.session?.user_type === 'user'
 
   const switchGuestMode = (mode) => {
     setSubmitError('')

--- a/frontend/src/router/AppRouter.jsx
+++ b/frontend/src/router/AppRouter.jsx
@@ -55,7 +55,7 @@ function CatchAllRedirect({ isAuthenticated, session }) {
 }
 
 export default function AppRouter({ auth, onLogout }) {
-  const isAuthenticated = Boolean(auth.token)
+  const isAuthenticated = Boolean(auth.session)
 
   return (
     <BrowserRouter>

--- a/frontend/src/services/authController.js
+++ b/frontend/src/services/authController.js
@@ -42,6 +42,19 @@ export class AuthController {
       sessionStore.clear()
     }
   }
+
+  async restore() {
+    // Repopulate session metadata from the HttpOnly cookie on app load. A 401
+    // (no/expired cookie) simply means "not logged in".
+    try {
+      const session = await authService.session()
+      sessionStore.setSession(session)
+      return session
+    } catch {
+      sessionStore.clear()
+      return null
+    }
+  }
 }
 
 export const authController = new AuthController()

--- a/frontend/src/services/authService.js
+++ b/frontend/src/services/authService.js
@@ -20,6 +20,10 @@ export class AuthService {
   async logout() {
     return httpClient.post('/api/v1/auth/logout', {})
   }
+
+  async session() {
+    return httpClient.get('/api/v1/auth/session')
+  }
 }
 
 export const authService = new AuthService()

--- a/frontend/src/services/httpClient.js
+++ b/frontend/src/services/httpClient.js
@@ -3,11 +3,6 @@ const API_BASE = import.meta.env.VITE_API_BASE_URL || ''
 export class HttpClient {
   constructor(baseUrl = API_BASE) {
     this.baseUrl = baseUrl
-    this.sessionToken = null
-  }
-
-  setSessionToken(token) {
-    this.sessionToken = token
   }
 
   async request(path, options = {}) {
@@ -16,12 +11,11 @@ export class HttpClient {
       ...(options.headers || {}),
     }
 
-    if (this.sessionToken) {
-      headers.Authorization = `Bearer ${this.sessionToken}`
-    }
-
+    // The session token lives in an HttpOnly cookie; send it automatically.
+    // Same-origin in prod (ingress) and dev (vite proxy), so 'include' is safe.
     const response = await fetch(`${this.baseUrl}${path}`, {
       ...options,
+      credentials: 'include',
       headers,
     })
 

--- a/frontend/src/services/sessionStore.js
+++ b/frontend/src/services/sessionStore.js
@@ -1,58 +1,50 @@
 import { httpClient } from './httpClient.js'
 
-const TOKEN_KEY = 'penahub.session.token'
-const SESSION_KEY = 'penahub.session.payload'
+const LEGACY_TOKEN_KEY = 'penahub.session.token'
+const LEGACY_SESSION_KEY = 'penahub.session.payload'
 
-const parseSession = (value) => {
-  if (!value) {
-    return null
-  }
+let currentSession = null
+
+const clearLegacyStorage = () => {
   try {
-    return JSON.parse(value)
+    localStorage.removeItem(LEGACY_TOKEN_KEY)
+    localStorage.removeItem(LEGACY_SESSION_KEY)
   } catch {
-    return null
+    // Storage may be unavailable in private or embedded browser contexts.
   }
 }
 
 export const sessionStore = {
   getToken() {
-    const session = this.getSession()
-    if (session?.token) {
-      return session.token
-    }
-    return localStorage.getItem(TOKEN_KEY)
+    return currentSession?.token ?? null
   },
   getSession() {
-    return parseSession(localStorage.getItem(SESSION_KEY))
+    return currentSession
   },
   setSession(session) {
     if (!session?.token) {
       return
     }
-    localStorage.setItem(SESSION_KEY, JSON.stringify(session))
-    localStorage.setItem(TOKEN_KEY, session.token)
+    currentSession = session
+    clearLegacyStorage()
     httpClient.setSessionToken(session.token)
   },
   setToken(token) {
     if (token) {
-      localStorage.setItem(TOKEN_KEY, token)
+      currentSession = { token }
+      clearLegacyStorage()
       httpClient.setSessionToken(token)
     }
   },
   clear() {
-    localStorage.removeItem(TOKEN_KEY)
-    localStorage.removeItem(SESSION_KEY)
+    currentSession = null
+    clearLegacyStorage()
     httpClient.setSessionToken(null)
   },
   init() {
-    const session = this.getSession()
-    if (session?.token) {
-      httpClient.setSessionToken(session.token)
-      return
-    }
-    const token = localStorage.getItem(TOKEN_KEY)
-    if (token) {
-      this.setToken(token)
+    clearLegacyStorage()
+    if (currentSession?.token) {
+      httpClient.setSessionToken(currentSession.token)
     }
   },
 }

--- a/frontend/src/services/sessionStore.js
+++ b/frontend/src/services/sessionStore.js
@@ -1,8 +1,9 @@
-import { httpClient } from './httpClient.js'
-
 const LEGACY_TOKEN_KEY = 'penahub.session.token'
 const LEGACY_SESSION_KEY = 'penahub.session.payload'
 
+// The session token now lives only in an HttpOnly cookie. This store keeps just
+// the non-sensitive metadata (role/guid) in memory for routing; it is repopulated
+// from GET /auth/session on reload.
 let currentSession = null
 
 const clearLegacyStorage = () => {
@@ -15,36 +16,22 @@ const clearLegacyStorage = () => {
 }
 
 export const sessionStore = {
-  getToken() {
-    return currentSession?.token ?? null
-  },
   getSession() {
     return currentSession
   },
   setSession(session) {
-    if (!session?.token) {
+    if (!session?.user_type) {
       return
     }
-    currentSession = session
-    clearLegacyStorage()
-    httpClient.setSessionToken(session.token)
-  },
-  setToken(token) {
-    if (token) {
-      currentSession = { token }
-      clearLegacyStorage()
-      httpClient.setSessionToken(token)
+    currentSession = {
+      user_guid: session.user_guid,
+      user_type: session.user_type,
+      expires_at: session.expires_at,
     }
+    clearLegacyStorage()
   },
   clear() {
     currentSession = null
     clearLegacyStorage()
-    httpClient.setSessionToken(null)
-  },
-  init() {
-    clearLegacyStorage()
-    if (currentSession?.token) {
-      httpClient.setSessionToken(currentSession.token)
-    }
   },
 }


### PR DESCRIPTION
# fix(security): rate limiting (#55) + HttpOnly cookie sessions (#122)

**Branch:** `task/#55+122` → `develop`
**Closes #55, Closes #122**

## Summary

Two security findings from the audit, both in the auth/API boundary:

- **#55** — no rate limiting on the backend (brute-force / password-spray exposure).
- **#122** — session tokens in `localStorage` (XSS-exfiltratable) + an error-detail-leak note.

8 commits, 27 files, **+632 / -97**. Backend **746 unit tests green**, ruff clean; frontend **eslint clean + `vite build` OK**; integration suite green against the CI stack.

## #55 — Backend rate limiting

- New `RateLimitMiddleware` + in-process `SlidingWindowRateLimiter` (`backend/src/api/middleware/rate_limit.py`): per-IP sliding window, tighter auth bucket (20/60s) vs default (300/60s), `429` with `Retry-After` + `X-RateLimit-*`, health/docs exempt, `OPTIONS` skipped. Env-configurable (`RATE_LIMIT_ENABLED | REQUESTS | AUTH_REQUESTS | WINDOW_SECONDS`).
- **CORS-safe 429s:** CORS middleware moved to outermost so short-circuit responses (429, TrustedHost 400) carry `Access-Control-*` headers instead of surfacing as opaque CORS errors in the browser.
- **Bounded memory:** sweeps fully-expired buckets every 1024 checks so the key table can't grow unbounded under rotating IPs.
- Hardening rider: `APP_ENV` default flipped `development → production`, which also closes the **#122 error-detail-leak note** (debug detail now off unless explicitly dev + flag).
- Helm wired: `values.yaml`, `templates/config.yaml`, `examples/values-prod.yaml`.

## #122 — HttpOnly cookie sessions

- **Backend:** `set_session_cookie` / `clear_session_cookie` (`HttpOnly`, `SameSite=Strict`, `Path=/`, `Secure` gated on non-dev `APP_ENV`, `Max-Age` from TTL) in `auth/dependencies.py`. `get_current_session` now also reads the `session` cookie (Bearer header kept for API clients/tests). Cookie set on login / admin-login / register / admin-register / claim; cleared on logout. New **`GET /auth/session`** returns metadata-only (`SessionResponse`, no token) for SPA reload restore.
- **Frontend:** `httpClient` uses `credentials: 'include'` and no longer touches the token; `sessionStore` keeps only `{ user_guid, user_type, expires_at }` in memory; `useAuth` restores from `/auth/session` on mount with a `restoring` status, and `App` holds first paint until it settles (no logout-flash on reload). `isAuthenticated` now keys off `auth.session`.

**Net:** the token never enters JS or localStorage (XSS can't exfiltrate it) **and** the session survives reload. CSRF is covered by `SameSite=Strict` (same-origin via ingress in prod / vite proxy in dev) — no CSRF token needed now.

## Tests

- **Rate limiter:** window blocking/scoping, idle-key eviction, middleware 429, runtime-config resolution.
- **Auth:** cookie helpers (HttpOnly / SameSite / Secure-in-prod / no-Secure-in-dev / clear), `_extract_token` cookie fallback + precedence, `get_current_session` reads cookie, `read_session` returns no token, `set-cookie` asserted on every login/register/claim/logout test.
- **Integration:** helpers send the admin-registration secret + 12-char passwords; `RATE_LIMIT_ENABLED=false` on the CI stack (single-IP test runner would otherwise trip the auth limit; limiter has its own unit tests).

## Reviewer notes / operational

- ⚠️ **Set `ADMIN_REGISTRATION_SECRET`** in every env (now in `.template.env`) — unset = admin registration disabled (fail-closed).
- ⚠️ Existing local `backend/config/.env` files need the new keys (`ADMIN_REGISTRATION_SECRET`, optionally `RATE_LIMIT_ENABLED=false` for local integration runs).
- Rate limiter is **per-replica, in-memory** — with multiple pods it's a first layer, not authoritative. Redis-backed is the upgrade path. IP trust also depends on tightening `forwarded_allow_ips` (separate finding).

## Out of scope (follow-ups)

- Claim endpoint (`RegisterAndClaimRequest`) password not yet under the 12-char min (#120 consistency).
- Redis-backed shared rate limiting; `forwarded_allow_ips` tightening.
