### PR TITLE
fix(deploy): allow backend probes with trusted hosts

### DIFF
--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -56,13 +56,19 @@ def _resolve_allowed_hosts() -> list[str]:
     raw_hosts = os.getenv("ALLOWED_HOSTS")
     if raw_hosts:
         hosts = [host.strip() for host in raw_hosts.split(",") if host.strip()]
-        if hosts:
-            return hosts
+    elif _app_env() in {"dev", "development", "local", "test"}:
+        hosts = ["localhost", "127.0.0.1", "::1", "testserver"]
+    else:
+        hosts = []
 
-    app_env = _app_env()
-    if app_env in {"dev", "development", "local", "test"}:
-        return ["localhost", "127.0.0.1", "::1", "testserver"]
-    return ["localhost"]
+    # Always allow loopback so in-cluster health probes (which send Host: localhost,
+    # not the configured public host) pass regardless of ALLOWED_HOSTS. Skip when "*"
+    # already allows everything.
+    if "*" not in hosts:
+        for loopback in ("localhost", "127.0.0.1"):
+            if loopback not in hosts:
+                hosts.append(loopback)
+    return hosts
 
 
 def _resolve_cors_origins() -> list[str]:

--- a/backend/tests/test_main_lifespan_and_hosts.py
+++ b/backend/tests/test_main_lifespan_and_hosts.py
@@ -20,7 +20,10 @@ class _Connection:
 
 def test_resolve_allowed_hosts_uses_explicit_env(monkeypatch):
     monkeypatch.setenv("ALLOWED_HOSTS", "api.example.com, app.example.com ,  ")
-    assert _resolve_allowed_hosts() == ["api.example.com", "app.example.com"]
+    hosts = _resolve_allowed_hosts()
+    assert hosts[:2] == ["api.example.com", "app.example.com"]
+    # Loopback is always appended so health probes pass.
+    assert "localhost" in hosts and "127.0.0.1" in hosts
 
 
 def test_resolve_allowed_hosts_uses_dev_defaults(monkeypatch):
@@ -35,7 +38,8 @@ def test_resolve_allowed_hosts_uses_dev_defaults(monkeypatch):
 def test_resolve_allowed_hosts_uses_safe_prod_default(monkeypatch):
     monkeypatch.delenv("ALLOWED_HOSTS", raising=False)
     monkeypatch.setenv("APP_ENV", "production")
-    assert _resolve_allowed_hosts() == ["localhost"]
+    # Prod denies by default except loopback (for health probes); no public host.
+    assert _resolve_allowed_hosts() == ["localhost", "127.0.0.1"]
 
 
 def test_db_startup_retries_parses_and_clamps(monkeypatch):

--- a/deploy/helm/footballhub/templates/backend.yaml
+++ b/deploy/helm/footballhub/templates/backend.yaml
@@ -35,12 +35,20 @@ spec:
             httpGet:
               path: /api/
               port: http
+              # TrustedHostMiddleware checks Host; probes hit the pod IP, so send a
+              # Host the app always allows (loopback) regardless of ALLOWED_HOSTS.
+              httpHeaders:
+                - name: Host
+                  value: localhost
             initialDelaySeconds: 5
             periodSeconds: 10
           livenessProbe:
             httpGet:
               path: /api/
               port: http
+              httpHeaders:
+                - name: Host
+                  value: localhost
             initialDelaySeconds: 15
             periodSeconds: 20
           resources:


### PR DESCRIPTION
fixes #36 
## Summary
- Allow backend loopback hosts even when `ALLOWED_HOSTS` is configured.
- Set Kubernetes readiness/liveness probes to send `Host: localhost`.
- Update host resolution tests for explicit hosts and production defaults.

## Validation
- `just check` OK, 758 passed
- `helm lint deploy/helm/footballhub` OK
- `helm template fhm deploy/helm/footballhub` OK