### PR TITLE
feat: added PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,24 @@
+<!-- Title must follow Conventional Commits, e.g. feat(backend): add pair player context -->
+
+## What & why
+<!-- Short description of the change and the motivation. -->
+
+Closes #
+
+## Type
+- [ ] feat
+- [ ] fix
+- [ ] docs
+- [ ] test
+- [ ] refactor / chore / perf / ci / build
+
+## Checklist
+- [ ] Backend gate passes: `just check` (format-check + lint + unit tests)
+- [ ] Frontend gate passes (if touched): `just frontend-check` (prettier + eslint + build)
+- [ ] DB schema changes also added to `versioning/sql/actual.sql` **and** a new `versioning/sql/versions/vN.sql`
+- [ ] User-facing text added to `frontend/src/i18n/messages.js` in **both** EN and ES
+- [ ] Tests added/updated for the change
+- [ ] Kept `pena`/GUID API contracts intact (unless the task explicitly changes them)
+
+## Notes for reviewers
+<!-- Screenshots, migration steps, anything out of the ordinary. -->

--- a/.gitmessage
+++ b/.gitmessage
@@ -1,0 +1,9 @@
+# <type>(<scope>): <subject>   (≤72 chars, imperative: "add" not "added")
+#
+# <body: what & why, wrap at 72>
+#
+# Refs: #<issue>
+#
+# ── type ──  feat | fix | docs | test | refactor | chore | perf | ci | build
+# ── scope ── backend | frontend | helm | deploy | db | auth | observability | audit
+# Example:  feat(backend): expose prometheus metrics endpoint

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,6 +138,7 @@ Use these local skills when the task matches:
 Repository-managed hooks live in `.githooks/`.
 
 - Install them once per clone with `just install-hooks`
+- Enable the shared commit template once per clone with `git config commit.template .gitmessage` (Conventional Commits: `type(scope): subject`)
 - `pre-commit` runs targeted lint/format checks for staged backend/frontend changes
 - `pre-push` runs full impacted quality gates before pushing
 


### PR DESCRIPTION
## What & why
Add a standard contribution setup for the repo: a Conventional Commits
message template, a GitHub PR template, and documentation on how to enable
the commit template. Keeps commits and PRs consistent with the conventions
already in use (feat/fix/docs + scopes, task/#NN branches).

Closes #140

## Type
- [ ] feat
- [ ] fix
- [x] docs
- [ ] test
- [ ] refactor / chore / perf / ci / build

## Checklist
- [ ] Backend gate passes: `just check` (format-check + lint + unit tests)
- [ ] Frontend gate passes (if touched): `just frontend-check` (prettier + eslint + build)
- [ ] DB schema changes also added to `versioning/sql/actual.sql` **and** a new `versioning/sql/versions/vN.sql`
- [ ] User-facing text added to `frontend/src/i18n/messages.js` in **both** EN and ES
- [ ] Tests added/updated for the change
- [ ] Kept `pena`/GUID API contracts intact (unless the task explicitly changes them)

_N/A — documentation/tooling only, no code, DB, i18n or API changes._

## Notes for reviewers
Files changed:
- `.github/pull_request_template.md` — auto-loads on new PRs
- `.gitmessage` — commit template (activate with `git config commit.template .gitmessage`)
- `AGENTS.md` — documents the commit-template setup step

`CONTRIBUTING.md` was intentionally dropped: the root `.md` files are gitignored
and `AGENTS.md`/`CLAUDE.md` are already the canonical contribution contract.
